### PR TITLE
Only absorb root part of pk in haraka message hashing.

### DIFF
--- a/ref/hash_haraka.c
+++ b/ref/hash_haraka.c
@@ -70,7 +70,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     haraka_S_inc_init(s_inc);
     haraka_S_inc_absorb(s_inc, R, SPX_N);
-    haraka_S_inc_absorb(s_inc, pk, SPX_PK_BYTES);
+    haraka_S_inc_absorb(s_inc, pk + SPX_N, SPX_N); // Only absorb root part of pk
     haraka_S_inc_absorb(s_inc, m, mlen);
     haraka_S_inc_finalize(s_inc);
     haraka_S_inc_squeeze(buf, SPX_DGST_BYTES, s_inc);


### PR DESCRIPTION
Patch to fix inconsistency with the NIST specification for hashing a message. Hashing the message now only includes the root part of the public key.