### PR TITLE
Initialize seed state in thashx8 test.

### DIFF
--- a/sha256-avx2/test/thashx8.c
+++ b/sha256-avx2/test/thashx8.c
@@ -5,6 +5,7 @@
 #include "../thash.h"
 #include "../randombytes.h"
 #include "../params.h"
+#include "../hash.h"
 
 int main()
 {
@@ -21,6 +22,8 @@ int main()
     randombytes(seed, SPX_N);
     randombytes(input, 8*SPX_N);
     randombytes((unsigned char *)addr, 8 * 8 * sizeof(uint32_t));
+
+    initialize_hash_function(seed, seed);
 
     printf("Testing if thash matches thashx8.. ");
 


### PR DESCRIPTION
When the state is left uninitialized, the test may fail.