### PR TITLE
Use GitHub workflows to test all implementations

### DIFF
--- a/.github/workflows/test-haraka-aesni.yml
+++ b/.github/workflows/test-haraka-aesni.yml
@@ -30,5 +30,8 @@ jobs:
           make -C haraka-aesni THASH=${{ matrix.thash }} clean
           make -C haraka-aesni THASH=${{ matrix.thash }} tests
           make -C haraka-aesni THASH=${{ matrix.thash }} test
+          make -C haraka-aesni THASH=${{ matrix.thash }} PQCgenKAT_sign
+      - name: Run PQCgenKAT_sign
+        run: ./haraka-aesni/PQCgenKAT_sign
 
 #  vim: set ft=yaml ts=2 sw=2 et :

--- a/.github/workflows/test-haraka-aesni.yml
+++ b/.github/workflows/test-haraka-aesni.yml
@@ -1,0 +1,33 @@
+name: Tests for haraka-aesni implementation
+
+on:
+  - push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        size:
+          - 128
+          - 192
+          - 256
+        option:
+          - s
+          - f
+        thash:
+          - simple
+          - robust
+    steps:
+      - uses: actions/checkout@v1
+      - name: Put params file in place
+        run: |
+          rm haraka-aesni/params.h
+          cp ref/params/params-sphincs-haraka-${{ matrix.size }}${{ matrix.option }}.h haraka-aesni/params.h
+      - name: Run make
+        run: |
+          make -C haraka-aesni THASH=${{ matrix.thash }} clean
+          make -C haraka-aesni THASH=${{ matrix.thash }} tests
+          make -C haraka-aesni THASH=${{ matrix.thash }} test
+
+#  vim: set ft=yaml ts=2 sw=2 et :

--- a/.github/workflows/test-haraka-aesni.yml
+++ b/.github/workflows/test-haraka-aesni.yml
@@ -2,6 +2,7 @@ name: Tests for haraka-aesni implementation
 
 on:
   - push
+  - pull_request
 
 jobs:
   build:

--- a/.github/workflows/test-ref.yml
+++ b/.github/workflows/test-ref.yml
@@ -2,6 +2,7 @@ name: Tests for ref implementation
 
 on:
   - push
+  - pull_request
 
 jobs:
   build:

--- a/.github/workflows/test-ref.yml
+++ b/.github/workflows/test-ref.yml
@@ -1,0 +1,37 @@
+name: Tests for ref implementation
+
+on:
+  - push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        hash:
+          - sha256
+          - shake256
+          - haraka
+        size:
+          - 128
+          - 192
+          - 256
+        option:
+          - s
+          - f
+        thash:
+          - simple
+          - robust
+    steps:
+      - uses: actions/checkout@v1
+      - name: Put params file in place
+        run: |
+          rm ref/params.h
+          cp ref/params/params-sphincs-${{ matrix.hash }}-${{ matrix.size }}${{ matrix.option }}.h ref/params.h
+      - name: Run make
+        run: |
+          make -C ref HASH=${{ matrix.hash }} THASH=${{ matrix.thash }} clean
+          make -C ref HASH=${{ matrix.hash }} THASH=${{ matrix.thash }} tests
+          make -C ref HASH=${{ matrix.hash }} THASH=${{ matrix.thash }} test
+
+#  vim: set ft=yaml ts=2 sw=2 et :

--- a/.github/workflows/test-ref.yml
+++ b/.github/workflows/test-ref.yml
@@ -34,5 +34,8 @@ jobs:
           make -C ref HASH=${{ matrix.hash }} THASH=${{ matrix.thash }} clean
           make -C ref HASH=${{ matrix.hash }} THASH=${{ matrix.thash }} tests
           make -C ref HASH=${{ matrix.hash }} THASH=${{ matrix.thash }} test
+          make -C ref THASH=${{ matrix.thash }} PQCgenKAT_sign
+      - name: Run PQCgenKAT_sign
+        run: ./ref/PQCgenKAT_sign
 
 #  vim: set ft=yaml ts=2 sw=2 et :

--- a/.github/workflows/test-sha256-avx2.yml
+++ b/.github/workflows/test-sha256-avx2.yml
@@ -2,6 +2,7 @@ name: Tests for sha256-avx2 implementation
 
 on:
   - push
+  - pull_request
 
 jobs:
   build:

--- a/.github/workflows/test-sha256-avx2.yml
+++ b/.github/workflows/test-sha256-avx2.yml
@@ -1,0 +1,33 @@
+name: Tests for sha256-avx2 implementation
+
+on:
+  - push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        size:
+          - 128
+          - 192
+          - 256
+        option:
+          - s
+          - f
+        thash:
+          - simple
+          - robust
+    steps:
+      - uses: actions/checkout@v1
+      - name: Put params file in place
+        run: |
+          rm sha256-avx2/params.h
+          cp ref/params/params-sphincs-sha256-${{ matrix.size }}${{ matrix.option }}.h sha256-avx2/params.h
+      - name: Run make
+        run: |
+          make -C sha256-avx2 THASH=${{ matrix.thash }} clean
+          make -C sha256-avx2 THASH=${{ matrix.thash }} tests
+          make -C sha256-avx2 THASH=${{ matrix.thash }} test
+
+#  vim: set ft=yaml ts=2 sw=2 et :

--- a/.github/workflows/test-sha256-avx2.yml
+++ b/.github/workflows/test-sha256-avx2.yml
@@ -30,5 +30,8 @@ jobs:
           make -C sha256-avx2 THASH=${{ matrix.thash }} clean
           make -C sha256-avx2 THASH=${{ matrix.thash }} tests
           make -C sha256-avx2 THASH=${{ matrix.thash }} test
+          make -C sha256-avx2 THASH=${{ matrix.thash }} PQCgenKAT_sign
+      - name: Run PQCgenKAT_sign
+        run: ./sha256-avx2/PQCgenKAT_sign
 
 #  vim: set ft=yaml ts=2 sw=2 et :

--- a/.github/workflows/test-shake256-avx2.yml
+++ b/.github/workflows/test-shake256-avx2.yml
@@ -30,5 +30,8 @@ jobs:
           make -C shake256-avx2 THASH=${{ matrix.thash }} clean
           make -C shake256-avx2 THASH=${{ matrix.thash }} tests
           make -C shake256-avx2 THASH=${{ matrix.thash }} test
+          make -C shake256-avx2 THASH=${{ matrix.thash }} PQCgenKAT_sign
+      - name: Run PQCgenKAT_sign
+        run: ./shake256-avx2/PQCgenKAT_sign
 
 #  vim: set ft=yaml ts=2 sw=2 et :

--- a/.github/workflows/test-shake256-avx2.yml
+++ b/.github/workflows/test-shake256-avx2.yml
@@ -1,0 +1,33 @@
+name: Tests for shake256-avx2 implementation
+
+on:
+  - push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        size:
+          - 128
+          - 192
+          - 256
+        option:
+          - s
+          - f
+        thash:
+          - simple
+          - robust
+    steps:
+      - uses: actions/checkout@v1
+      - name: Put params file in place
+        run: |
+          rm shake256-avx2/params.h
+          cp ref/params/params-sphincs-shake256-${{ matrix.size }}${{ matrix.option }}.h shake256-avx2/params.h
+      - name: Run make
+        run: |
+          make -C shake256-avx2 THASH=${{ matrix.thash }} clean
+          make -C shake256-avx2 THASH=${{ matrix.thash }} tests
+          make -C shake256-avx2 THASH=${{ matrix.thash }} test
+
+#  vim: set ft=yaml ts=2 sw=2 et :

--- a/.github/workflows/test-shake256-avx2.yml
+++ b/.github/workflows/test-shake256-avx2.yml
@@ -2,6 +2,7 @@ name: Tests for shake256-avx2 implementation
 
 on:
   - push
+  - pull_request
 
 jobs:
   build:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: c
-os:
-  - linux
-compiler:
-  - gcc
-script:
-  - make -C ref test
-  - make -C haraka-aesni test
-  # - make -C shake256-avx2 test  # cannot currently test this on TravisCI

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-## SPHINCS+ [![Build Status](https://travis-ci.org/sphincs/sphincsplus.svg?branch=master)](https://travis-ci.org/sphincs/sphincsplus)
+## SPHINCS+ ![][test-ref] ![][test-sha256-avx2] ![][test-shake256-avx2] ![][test-haraka-aesni]
+
+[test-ref]: https://github.com/sphincs/sphincsplus/workflows/test-ref/badge.svg
+[test-sha256-avx2]: https://github.com/sphincs/sphincsplus/workflows/test-sha256-avx2/badge.svg
+[test-shake256-avx2]: https://github.com/sphincs/sphincsplus/workflows/test-shake256-avx2/badge.svg
+[test-haraka-aesni]: https://github.com/sphincs/sphincsplus/workflows/test-haraka-aesni/badge.svg
 
 This repository contains the software that accompanies the [SPHINCS+ submission](https://sphincs.org/) to [NIST's Post-Quantum Cryptography](https://csrc.nist.gov/Projects/Post-Quantum-Cryptography) project.
 


### PR DESCRIPTION
The `.travis.yml` contains a comment that the infrastructure run by Travis-ci is too old to allow for testing the AVX2-based implementation. It is also a bit slow, so running all the schemes might have been viewed as something that is not entirely practical.

This PR moves the CI testing to Github Workflows, a new CI platform integrated in Github, available for free. The build runners are much more modern, so I've now added tests for all implementations and all parameter sets.
