### PR TITLE
Speed up SHAKE by using f1600x4 directly instead of shake256x4

### DIFF
--- a/shake256-avx2/thash_shake256_robustx4.c
+++ b/shake256-avx2/thash_shake256_robustx4.c
@@ -7,6 +7,13 @@
 
 #include "fips202x4.h"
 
+extern void KeccakP1600times4_PermuteAll_24rounds(__m256i *s);
+
+static uint32_t swap32(uint32_t val) {
+    val = ((val << 8) & 0xFF00FF00 ) | ((val >> 8) & 0xFF00FF );
+    return (val << 16) | (val >> 16);
+}
+
 /**
  * 4-way parallel version of thash; takes 4x as much input and output
  */
@@ -20,35 +27,195 @@ void thashx4(unsigned char *out0,
              const unsigned char *in3, unsigned int inblocks,
              const unsigned char *pub_seed, uint32_t addrx4[4*8])
 {
-    unsigned char buf0[SPX_N + SPX_ADDR_BYTES + inblocks*SPX_N];
-    unsigned char buf1[SPX_N + SPX_ADDR_BYTES + inblocks*SPX_N];
-    unsigned char buf2[SPX_N + SPX_ADDR_BYTES + inblocks*SPX_N];
-    unsigned char buf3[SPX_N + SPX_ADDR_BYTES + inblocks*SPX_N];
-    unsigned char bitmask0[inblocks * SPX_N];
-    unsigned char bitmask1[inblocks * SPX_N];
-    unsigned char bitmask2[inblocks * SPX_N];
-    unsigned char bitmask3[inblocks * SPX_N];
-    unsigned int i;
+    if (SPX_N <= 32 && (inblocks == 1 || inblocks == 2)) {
+        /* As we write and read only a few quadwords, it is more efficient to
+         * build and extract from the fourway SHAKE256 state by hand. */
+        __m256i state[25];
+        for (int i = 0; i < SPX_N/8; i++) {
+            state[i] = _mm256_set1_epi64x(((int64_t*)pub_seed)[i]);
+        }
+        for (int i = 0; i < 4; i++) {
+            state[SPX_N/8+i] = _mm256_set_epi32(
+                swap32(addrx4[3*8+1+2*i]),
+                swap32(addrx4[3*8+2*i]),
+                swap32(addrx4[2*8+1+2*i]),
+                swap32(addrx4[2*8+2*i]),
+                swap32(addrx4[8+1+2*i]),
+                swap32(addrx4[8+2*i]),
+                swap32(addrx4[1+2*i]),
+                swap32(addrx4[2*i])
+            );
+        }
 
-    memcpy(buf0, pub_seed, SPX_N);
-    memcpy(buf1, pub_seed, SPX_N);
-    memcpy(buf2, pub_seed, SPX_N);
-    memcpy(buf3, pub_seed, SPX_N);
-    addr_to_bytes(buf0 + SPX_N, addrx4 + 0*8);
-    addr_to_bytes(buf1 + SPX_N, addrx4 + 1*8);
-    addr_to_bytes(buf2 + SPX_N, addrx4 + 2*8);
-    addr_to_bytes(buf3 + SPX_N, addrx4 + 3*8);
+        /* SHAKE domain separator and padding */
+        state[SPX_N/8+4] = _mm256_set1_epi64x(0x1f);
+        for (int i = SPX_N/8+5; i < 16; i++) {
+            state[i] = _mm256_set1_epi64x(0);
+        }
+        state[16] = _mm256_set1_epi64x(0x80ll << 56);
 
-    shake256x4(bitmask0, bitmask1, bitmask2, bitmask3, inblocks * SPX_N,
-               buf0, buf1, buf2, buf3, SPX_N + SPX_ADDR_BYTES);
+        for (int i = 17; i < 25; i++) {
+            state[i] = _mm256_set1_epi64x(0);
+        }
 
-    for (i = 0; i < inblocks * SPX_N; i++) {
-        buf0[SPX_N + SPX_ADDR_BYTES + i] = in0[i] ^ bitmask0[i];
-        buf1[SPX_N + SPX_ADDR_BYTES + i] = in1[i] ^ bitmask1[i];
-        buf2[SPX_N + SPX_ADDR_BYTES + i] = in2[i] ^ bitmask2[i];
-        buf3[SPX_N + SPX_ADDR_BYTES + i] = in3[i] ^ bitmask3[i];
+        /* We will permutate state2 with f1600x4 to compute the bitmask,
+         * but first we'll copy it to state2 which will be used to compute
+         * the final output, as its input is alsmost identical. */
+        __m256i state2[25];
+        memcpy(state2, state, 800);
+
+        KeccakP1600times4_PermuteAll_24rounds(&state[0]);
+
+        /* By copying from state, state2 already contains the pub_seed
+         * and addres.  We just need to copy in the input blocks xorred with
+         * the bitmask we just computed. */
+        for (unsigned int i = 0; i < (SPX_N/8) * inblocks; i++) {
+            state2[SPX_N/8+4+i] = _mm256_xor_si256(
+                    state[i],
+                    _mm256_set_epi64x(
+                        ((int64_t*)in3)[i],
+                        ((int64_t*)in2)[i],
+                        ((int64_t*)in1)[i],
+                        ((int64_t*)in0)[i]
+                    )
+                );
+        }
+
+        /* Domain separator and start of padding.  Note that the quadwords
+         * around are already zeroed for state from which we copied.
+         * We do a XOR instead of a set as this might be the 16th quadword
+         * when N=32 and inblocks=2, which already contains the end
+         * of the padding. */
+        state2[(SPX_N/8)*(1+inblocks)+4] = _mm256_xor_si256(
+            state2[(SPX_N/8)*(1+inblocks)+4],
+            _mm256_set1_epi64x(0x1f)
+        );
+
+        KeccakP1600times4_PermuteAll_24rounds(&state2[0]);
+
+        for (int i = 0; i < SPX_N/8; i++) {
+            ((int64_t*)out0)[i] = _mm256_extract_epi64(state2[i], 0);
+            ((int64_t*)out1)[i] = _mm256_extract_epi64(state2[i], 1);
+            ((int64_t*)out2)[i] = _mm256_extract_epi64(state2[i], 2);
+            ((int64_t*)out3)[i] = _mm256_extract_epi64(state2[i], 3);
+        }
+    } else if (SPX_N == 64 && (inblocks == 1 || inblocks == 2)) {
+        /* As we write and read only a few quadwords, it is more efficient to
+         * build and extract from the fourway SHAKE256 state by hand. */
+        __m256i state[25];
+        for (int i = 0; i < 8; i++) {
+            state[i] = _mm256_set1_epi64x(((int64_t*)pub_seed)[i]);
+        }
+        for (int i = 0; i < 4; i++) {
+            state[8+i] = _mm256_set_epi32(
+                swap32(addrx4[3*8+1+2*i]),
+                swap32(addrx4[3*8+2*i]),
+                swap32(addrx4[2*8+1+2*i]),
+                swap32(addrx4[2*8+2*i]),
+                swap32(addrx4[8+1+2*i]),
+                swap32(addrx4[8+2*i]),
+                swap32(addrx4[1+2*i]),
+                swap32(addrx4[2*i])
+            );
+        }
+
+        /* SHAKE domain separator and padding */
+        state[8+4] = _mm256_set1_epi64x(0x1f);
+        for (int i = 8+5; i < 16; i++) {
+            state[i] = _mm256_set1_epi64x(0);
+        }
+        state[16] = _mm256_set1_epi64x(0x80ll << 56);
+
+        for (int i = 17; i < 25; i++) {
+            state[i] = _mm256_set1_epi64x(0);
+        }
+
+        /* We will permutate state2 with f1600x4 to compute the bitmask,
+         * but first we'll copy it to state2 which will be used to compute
+         * the final output, as its input is alsmost identical. */
+        __m256i state2[25];
+        memcpy(state2, state, 800);
+
+        KeccakP1600times4_PermuteAll_24rounds(&state[0]);
+
+        /* We will won't be able to fit all input in on go.
+         * By copying from state, state2 already contains the pub_seed
+         * and addres.  We just need to copy in the input blocks xorred with
+         * the bitmask we just computed. */
+        for (unsigned int i = 0; i < 5; i++) {
+            state2[8+4+i] = _mm256_xor_si256(
+                    state[i],
+                    _mm256_set_epi64x(
+                        ((int64_t*)in3)[i],
+                        ((int64_t*)in2)[i],
+                        ((int64_t*)in1)[i],
+                        ((int64_t*)in0)[i]
+                    )
+                );
+        }
+
+        KeccakP1600times4_PermuteAll_24rounds(&state2[0]);
+
+        /* Final input. */
+        for (unsigned int i = 0; i < 3+8*(inblocks-1); i++) {
+            state2[i] = _mm256_xor_si256(
+                    state2[i],
+                    _mm256_xor_si256(
+                        state[i+5],
+                        _mm256_set_epi64x(
+                            ((int64_t*)in3)[i+5],
+                            ((int64_t*)in2)[i+5],
+                            ((int64_t*)in1)[i+5],
+                            ((int64_t*)in0)[i+5]
+                        )
+                    )
+                );
+        }
+
+        /* Domain separator and padding. */
+        state2[3+8*(inblocks-1)] = _mm256_xor_si256(state2[3+8*(inblocks-1)],
+                _mm256_set1_epi64x(0x1f));
+        state2[16] = _mm256_xor_si256(state2[16], _mm256_set1_epi64x(0x80ll << 56));
+
+        KeccakP1600times4_PermuteAll_24rounds(&state2[0]);
+
+        for (int i = 0; i < 8; i++) {
+            ((int64_t*)out0)[i] = _mm256_extract_epi64(state2[i], 0);
+            ((int64_t*)out1)[i] = _mm256_extract_epi64(state2[i], 1);
+            ((int64_t*)out2)[i] = _mm256_extract_epi64(state2[i], 2);
+            ((int64_t*)out3)[i] = _mm256_extract_epi64(state2[i], 3);
+        }
+    } else {
+        unsigned char buf0[SPX_N + SPX_ADDR_BYTES + inblocks*SPX_N];
+        unsigned char buf1[SPX_N + SPX_ADDR_BYTES + inblocks*SPX_N];
+        unsigned char buf2[SPX_N + SPX_ADDR_BYTES + inblocks*SPX_N];
+        unsigned char buf3[SPX_N + SPX_ADDR_BYTES + inblocks*SPX_N];
+        unsigned char bitmask0[inblocks * SPX_N];
+        unsigned char bitmask1[inblocks * SPX_N];
+        unsigned char bitmask2[inblocks * SPX_N];
+        unsigned char bitmask3[inblocks * SPX_N];
+        unsigned int i;
+
+        memcpy(buf0, pub_seed, SPX_N);
+        memcpy(buf1, pub_seed, SPX_N);
+        memcpy(buf2, pub_seed, SPX_N);
+        memcpy(buf3, pub_seed, SPX_N);
+        addr_to_bytes(buf0 + SPX_N, addrx4 + 0*8);
+        addr_to_bytes(buf1 + SPX_N, addrx4 + 1*8);
+        addr_to_bytes(buf2 + SPX_N, addrx4 + 2*8);
+        addr_to_bytes(buf3 + SPX_N, addrx4 + 3*8);
+
+        shake256x4(bitmask0, bitmask1, bitmask2, bitmask3, inblocks * SPX_N,
+                   buf0, buf1, buf2, buf3, SPX_N + SPX_ADDR_BYTES);
+
+        for (i = 0; i < inblocks * SPX_N; i++) {
+            buf0[SPX_N + SPX_ADDR_BYTES + i] = in0[i] ^ bitmask0[i];
+            buf1[SPX_N + SPX_ADDR_BYTES + i] = in1[i] ^ bitmask1[i];
+            buf2[SPX_N + SPX_ADDR_BYTES + i] = in2[i] ^ bitmask2[i];
+            buf3[SPX_N + SPX_ADDR_BYTES + i] = in3[i] ^ bitmask3[i];
+        }
+
+        shake256x4(out0, out1, out2, out3, SPX_N,
+                   buf0, buf1, buf2, buf3, SPX_N + SPX_ADDR_BYTES + inblocks*SPX_N);
     }
-
-    shake256x4(out0, out1, out2, out3, SPX_N,
-               buf0, buf1, buf2, buf3, SPX_N + SPX_ADDR_BYTES + inblocks*SPX_N);
 }


### PR DESCRIPTION
The generic shake256x4 has considerable overhead over the underlying
permutation as it has to tranpose all incoming and outgoing data; and
work for different input and output lengths.

For thashx4 and prf_addrx4, the input size is known, the size
is smaller than the complete state and is for some quadwords identical
for all lanes.  By constructing and reading from the fourway state by
hand, the compiler can do a way better job.

This yield a nice speedup.

Old:

```
Parameters: n = 32, h = 64, d = 8, b = 14, k = 22, w = 16
Running 10 iterations.
Generating keypair.. avg.   124185.80 us (0.12 sec); median    353,740,630 cycles,      1x:    353,740,630 cycles
  - WOTS pk gen..    avg.      469.60 us (0.00 sec); median      1,297,772 cycles,    256x:    332,229,632 cycles
Signing..            avg.  1412992.80 us (1.41 sec); median  3,961,513,594 cycles,      1x:  3,961,513,594 cycles
  - FORS signing..   avg.   456295.10 us (0.46 sec); median  1,282,159,337 cycles,      1x:  1,282,159,337 cycles
  - WOTS signing..   avg.       93.50 us (0.00 sec); median        260,994 cycles,      8x:      2,087,952 cycles
  - WOTS pk gen..    avg.      469.50 us (0.00 sec); median      1,297,817 cycles,   2048x:  2,657,929,216 cycles
Verifying..          avg.     2272.40 us (0.00 sec); median      6,378,965 cycles,      1x:      6,378,965 cycles
```

New:
```
Parameters: n = 32, h = 64, d = 8, b = 14, k = 22, w = 16
Running 10 iterations.
Generating keypair.. avg.    64447.90 us (0.06 sec); median    180,103,023 cycles,      1x:    180,103,023 cycles
  - WOTS pk gen..    avg.      248.40 us (0.00 sec); median        673,056 cycles,    256x:    172,302,336 cycles
Signing..            avg.   864298.30 us (0.86 sec); median  2,430,533,372 cycles,      1x:  2,430,533,372 cycles
  - FORS signing..   avg.   333202.90 us (0.33 sec); median    934,939,607 cycles,      1x:    934,939,607 cycles
  - WOTS signing..   avg.       43.00 us (0.00 sec); median        112,891 cycles,      8x:        903,128 cycles
  - WOTS pk gen..    avg.      259.40 us (0.00 sec); median        730,774 cycles,   2048x:  1,496,625,152 cycles
Verifying..          avg.     1376.70 us (0.00 sec); median      3,761,284 cycles,      1x:      3,761,284 cycles
```

Note: the duplicated swap32 helper and `KeccakP1600times4_PermuteAll_24rounds` external declaration should be cleaned up, but I'll leave that to you.