### PR TITLE
Use specialization of ull_to_bytes to uint32

### DIFF
--- a/ref/address.c
+++ b/ref/address.c
@@ -8,7 +8,7 @@ void addr_to_bytes(unsigned char *bytes, const uint32_t addr[8])
     int i;
 
     for (i = 0; i < 8; i++) {
-        ull_to_bytes(bytes + i*4, 4, addr[i]);
+        u32_to_bytes(bytes + i*4, addr[i]);
     }
 }
 

--- a/ref/sha256.c
+++ b/ref/sha256.c
@@ -336,13 +336,13 @@ void sha256(uint8_t *out, const uint8_t *in, size_t inlen) {
  */
 void compress_address(unsigned char *out, const uint32_t addr[8])
 {
-    ull_to_bytes(out,      1, addr[0]); /* drop 3 bytes of the layer field */
-    ull_to_bytes(out + 1,  4, addr[2]); /* drop the highest tree address word */
-    ull_to_bytes(out + 5,  4, addr[3]);
-    ull_to_bytes(out + 9,  1, addr[4]); /* drop 3 bytes of the type field */
-    ull_to_bytes(out + 10, 4, addr[5]);
-    ull_to_bytes(out + 14, 4, addr[6]);
-    ull_to_bytes(out + 18, 4, addr[7]);
+    out[0] = (unsigned char)addr[0]; /* drop 3 bytes of the layer field */
+    u32_to_bytes(out + 1,  addr[2]); /* drop the highest tree address word */
+    u32_to_bytes(out + 5,  addr[3]);
+    out[9] = (unsigned char)addr[4]; /* drop 3 byres of the type field */
+    u32_to_bytes(out + 10, addr[5]);
+    u32_to_bytes(out + 14, addr[6]);
+    u32_to_bytes(out + 18, addr[7]);
 }
 
 /**
@@ -361,13 +361,13 @@ void mgf1(unsigned char *out, unsigned long outlen,
 
     /* While we can fit in at least another full block of SHA256 output.. */
     for (i = 0; (i+1)*SPX_SHA256_OUTPUT_BYTES <= outlen; i++) {
-        ull_to_bytes(inbuf + inlen, 4, i);
+        u32_to_bytes(inbuf + inlen, i);
         sha256(out, inbuf, inlen + 4);
         out += SPX_SHA256_OUTPUT_BYTES;
     }
     /* Until we cannot anymore, and we fill the remainder. */
     if (outlen > i*SPX_SHA256_OUTPUT_BYTES) {
-        ull_to_bytes(inbuf + inlen, 4, i);
+        u32_to_bytes(inbuf + inlen, i);
         sha256(outbuf, inbuf, inlen + 4);
         memcpy(out, outbuf, outlen - i*SPX_SHA256_OUTPUT_BYTES);
     }

--- a/ref/utils.c
+++ b/ref/utils.c
@@ -21,6 +21,14 @@ void ull_to_bytes(unsigned char *out, unsigned int outlen,
     }
 }
 
+void u32_to_bytes(unsigned char *out, uint32_t in)
+{
+    out[0] = (unsigned char)(in >> 24);
+    out[1] = (unsigned char)(in >> 16);
+    out[2] = (unsigned char)(in >> 8);
+    out[3] = (unsigned char)in;
+}
+
 /**
  * Converts the inlen bytes in 'in' from big-endian byte order to an integer.
  */

--- a/ref/utils.h
+++ b/ref/utils.h
@@ -4,11 +4,13 @@
 #include <stdint.h>
 #include "params.h"
 
+
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
  */
 void ull_to_bytes(unsigned char *out, unsigned int outlen,
                   unsigned long long in);
+void u32_to_bytes(unsigned char *out, uint32_t in);
 
 /**
  * Converts the inlen bytes in 'in' from big-endian byte order to an integer.

--- a/sha256-avx2/sha256x8.c
+++ b/sha256-avx2/sha256x8.c
@@ -61,7 +61,7 @@ void mgf1x8(unsigned char *outx8, unsigned long outlen,
     /* While we can fit in at least another full block of SHA256 output.. */
     for (i = 0; (i+1)*SPX_SHA256_OUTPUT_BYTES <= outlen; i++) {
         for (j = 0; j < 8; j++) {
-            ull_to_bytes(inbufx8 + inlen + j*(inlen + 4), 4, i);
+            u32_to_bytes(inbufx8 + inlen + j*(inlen + 4), i);
         }
 
         sha256x8(outx8 + 0*outlen,
@@ -84,7 +84,7 @@ void mgf1x8(unsigned char *outx8, unsigned long outlen,
     }
     /* Until we cannot anymore, and we fill the remainder. */
     for (j = 0; j < 8; j++) {
-        ull_to_bytes(inbufx8 + inlen + j*(inlen + 4), 4, i);
+        u32_to_bytes(inbufx8 + inlen + j*(inlen + 4), i);
     }
     sha256x8(outbufx8 + 0*SPX_SHA256_OUTPUT_BYTES,
              outbufx8 + 1*SPX_SHA256_OUTPUT_BYTES,


### PR DESCRIPTION
Compilers aren't the best at guessing specializations.