### PR TITLE
haraka-aesni: fix aligned loads from unaligned mem

### DIFF
--- a/haraka-aesni/haraka.c
+++ b/haraka-aesni/haraka.c
@@ -15,7 +15,7 @@ Plain C implementation of the Haraka256 and Haraka512 permutations.
 #define u64 unsigned long
 #define u128 __m128i
 
-#define LOAD(src) _mm_load_si128((u128 *)(src))
+#define LOAD(src) _mm_loadu_si128((u128 *)(src))
 #define STORE(dest,src) _mm_storeu_si128((u128 *)(dest),src)
 
 #define XOR128(a, b) _mm_xor_si128(a, b)


### PR DESCRIPTION
This originates from [a bug report against libOQS](https://github.com/open-quantum-safe/liboqs/issues/808).

This PR simply changes the aligned loads to unaligned loads; perhaps we can be more subtle about it by going through `haraka.c` in more detail to see which loads can be aligned ― right now it looks like it's all just `char` arrays.

In the issue thread at liboqs, Douglas remarks that Intel does not document a performance difference. I didn't check ― I'd be happy to hear your thoughts.