### PR TITLE
Simplify SHA256x8 for the compiler

### DIFF
--- a/ref/sha256.h
+++ b/ref/sha256.h
@@ -21,7 +21,7 @@ void sha256(uint8_t *out, const uint8_t *in, size_t inlen);
 void mgf1(unsigned char *out, unsigned long outlen,
           const unsigned char *in, unsigned long inlen);
 
-uint8_t state_seeded[40];
+extern uint8_t state_seeded[40];
 
 void seed_state(const unsigned char *pub_seed);
 

--- a/sha256-avx2/sha256avx.c
+++ b/sha256-avx2/sha256avx.c
@@ -34,23 +34,6 @@ void transpose(u256 s[8]) {
     s[7] = _mm256_permute2x128_si256(tmp1[3], tmp1[7], 0x31);    
 }
 
-static uint32_t load_bigendian_32(const uint8_t *x) {
-    return (uint32_t)(x[3]) | (((uint32_t)(x[2])) << 8) |
-           (((uint32_t)(x[1])) << 16) | (((uint32_t)(x[0])) << 24);
-}
-
-void sha256_init_frombytes_x8(sha256ctx *ctx, uint8_t *s, unsigned long long msglen) {
-    uint32_t t;
-
-    for (size_t i = 0; i < 8; i++) {
-        t = load_bigendian_32(s + 4*i);
-        ctx->s[i] = _mm256_set_epi32(t, t, t, t, t, t, t, t);
-    }
-
-    ctx->datalen = 0;
-    ctx->msglen = msglen;
-}
-
 void sha256_init8x(sha256ctx *ctx) {
     ctx->s[0] = _mm256_set_epi32(0x6a09e667,0x6a09e667,0x6a09e667,0x6a09e667,0x6a09e667,0x6a09e667,0x6a09e667,0x6a09e667);
     ctx->s[1] = _mm256_set_epi32(0xbb67ae85,0xbb67ae85,0xbb67ae85,0xbb67ae85,0xbb67ae85,0xbb67ae85,0xbb67ae85,0xbb67ae85);

--- a/sha256-avx2/sha256avx.h
+++ b/sha256-avx2/sha256avx.h
@@ -72,7 +72,6 @@ typedef struct SHA256state {
 
 
 void transpose(u256 s[8]);
-void sha256_init_frombytes_x8(sha256ctx *ctx, uint8_t *s, unsigned long long msglen);
 void sha256_init8x(sha256ctx *ctx);
 void sha256_update8x(sha256ctx *ctx, 
                      const unsigned char *d0,

--- a/sha256-avx2/sha256avx.h
+++ b/sha256-avx2/sha256avx.h
@@ -73,16 +73,6 @@ typedef struct SHA256state {
 
 void transpose(u256 s[8]);
 void sha256_init8x(sha256ctx *ctx);
-void sha256_update8x(sha256ctx *ctx, 
-                     const unsigned char *d0,
-                     const unsigned char *d1,
-                     const unsigned char *d2,
-                     const unsigned char *d3,
-                     const unsigned char *d4,
-                     const unsigned char *d5,
-                     const unsigned char *d6,
-                     const unsigned char *d7,
-                     unsigned long long len);
 void sha256_final8x(sha256ctx *ctx,
                     unsigned char *out0,
                     unsigned char *out1,
@@ -93,7 +83,14 @@ void sha256_final8x(sha256ctx *ctx,
                     unsigned char *out6,
                     unsigned char *out7);
 
-void sha256_transform8x(sha256ctx *ctx, const unsigned char *data);
-
+void sha256_transform8x(sha256ctx *ctx,
+        const unsigned char *data0,
+        const unsigned char *data1,
+        const unsigned char *data2,
+        const unsigned char *data3,
+        const unsigned char *data4,
+        const unsigned char *data5,
+        const unsigned char *data6,
+        const unsigned char *data7);
 
 #endif

--- a/sha256-avx2/sha256x8.c
+++ b/sha256-avx2/sha256x8.c
@@ -4,7 +4,6 @@
 #include "sha256avx.h"
 #include "utils.h"
 
-// TODO deduplicate
 static uint32_t load_bigendian_32(const uint8_t *x) {
     return (uint32_t)(x[3]) | (((uint32_t)(x[2])) << 8) |
            (((uint32_t)(x[1])) << 16) | (((uint32_t)(x[0])) << 24);

--- a/sha256-avx2/sha256x8.h
+++ b/sha256-avx2/sha256x8.h
@@ -8,6 +8,26 @@
     #error Linking against SHA-256 with N larger than 32 bytes is not supported
 #endif
 
+void sha256x8_seeded(
+              unsigned char *out0,
+              unsigned char *out1,
+              unsigned char *out2,
+              unsigned char *out3,
+              unsigned char *out4,
+              unsigned char *out5,
+              unsigned char *out6,
+              unsigned char *out7,
+              const unsigned char *seed,
+              unsigned long long seedlen,
+              const unsigned char *in0,
+              const unsigned char *in1,
+              const unsigned char *in2,
+              const unsigned char *in3,
+              const unsigned char *in4,
+              const unsigned char *in5,
+              const unsigned char *in6,
+              const unsigned char *in7, unsigned long long inlen);
+
 /* This provides a wrapper around the internals of 8x parallel SHA256 */
 void sha256x8(unsigned char *out0,
               unsigned char *out1,

--- a/sha256-avx2/thash_sha256_robustx8.c
+++ b/sha256-avx2/thash_sha256_robustx8.c
@@ -34,7 +34,6 @@ void thashx8(unsigned char *out0,
     unsigned char outbufx8[8*SPX_SHA256_OUTPUT_BYTES];
     unsigned char bitmaskx8[8*(inblocks * SPX_N)];
     unsigned int i;
-    sha256ctx ctx;
 
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
@@ -56,8 +55,6 @@ void thashx8(unsigned char *out0,
            bufx8 + 6*(SPX_N + SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
            bufx8 + 7*(SPX_N + SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
            SPX_N + SPX_SHA256_ADDR_BYTES);
-
-    sha256_init_frombytes_x8(&ctx, state_seeded, 512);
 
     for (i = 0; i < inblocks * SPX_N; i++) {
         bufx8[SPX_N + SPX_SHA256_ADDR_BYTES + i +
@@ -86,26 +83,31 @@ void thashx8(unsigned char *out0,
             in7[i] ^ bitmaskx8[i + 7*(inblocks * SPX_N)];
     }
 
-    sha256_update8x(&ctx,
-                    bufx8 + SPX_N + 0*(SPX_N + SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
-                    bufx8 + SPX_N + 1*(SPX_N + SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
-                    bufx8 + SPX_N + 2*(SPX_N + SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
-                    bufx8 + SPX_N + 3*(SPX_N + SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
-                    bufx8 + SPX_N + 4*(SPX_N + SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
-                    bufx8 + SPX_N + 5*(SPX_N + SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
-                    bufx8 + SPX_N + 6*(SPX_N + SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
-                    bufx8 + SPX_N + 7*(SPX_N + SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
-                    SPX_SHA256_ADDR_BYTES + inblocks*SPX_N);
+    sha256x8_seeded(
+        /* out */
+        outbufx8 + 0*SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + 1*SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + 2*SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + 3*SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + 4*SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + 5*SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + 6*SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + 7*SPX_SHA256_OUTPUT_BYTES,
 
-    sha256_final8x(&ctx,
-                   outbufx8 + 0*SPX_SHA256_OUTPUT_BYTES,
-                   outbufx8 + 1*SPX_SHA256_OUTPUT_BYTES,
-                   outbufx8 + 2*SPX_SHA256_OUTPUT_BYTES,
-                   outbufx8 + 3*SPX_SHA256_OUTPUT_BYTES,
-                   outbufx8 + 4*SPX_SHA256_OUTPUT_BYTES,
-                   outbufx8 + 5*SPX_SHA256_OUTPUT_BYTES,
-                   outbufx8 + 6*SPX_SHA256_OUTPUT_BYTES,
-                   outbufx8 + 7*SPX_SHA256_OUTPUT_BYTES);
+        /* seed */
+        state_seeded, 512,
+
+        /* in */
+        bufx8 + SPX_N + 0*(SPX_N + SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
+        bufx8 + SPX_N + 1*(SPX_N + SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
+        bufx8 + SPX_N + 2*(SPX_N + SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
+        bufx8 + SPX_N + 3*(SPX_N + SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
+        bufx8 + SPX_N + 4*(SPX_N + SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
+        bufx8 + SPX_N + 5*(SPX_N + SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
+        bufx8 + SPX_N + 6*(SPX_N + SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
+        bufx8 + SPX_N + 7*(SPX_N + SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
+        SPX_SHA256_ADDR_BYTES + inblocks*SPX_N /* len */
+    );
 
     memcpy(out0, outbufx8 + 0*SPX_SHA256_OUTPUT_BYTES, SPX_N);
     memcpy(out1, outbufx8 + 1*SPX_SHA256_OUTPUT_BYTES, SPX_N);

--- a/sha256-avx2/thash_sha256_simplex8.c
+++ b/sha256-avx2/thash_sha256_simplex8.c
@@ -33,11 +33,8 @@ void thashx8(unsigned char *out0,
     unsigned char bufx8[8*(SPX_SHA256_ADDR_BYTES + inblocks*SPX_N)];
     unsigned char outbufx8[8*SPX_SHA256_OUTPUT_BYTES];
     unsigned int i;
-    sha256ctx ctx;
 
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
-
-    sha256_init_frombytes_x8(&ctx, state_seeded, 512);
 
     for (i = 0; i < 8; i++) {
         memcpy(bufx8 + i*(SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
@@ -61,26 +58,31 @@ void thashx8(unsigned char *out0,
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
         7*(SPX_SHA256_ADDR_BYTES + inblocks*SPX_N), in7, inblocks * SPX_N);
 
-    sha256_update8x(&ctx,
-                    bufx8 + 0*(SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
-                    bufx8 + 1*(SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
-                    bufx8 + 2*(SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
-                    bufx8 + 3*(SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
-                    bufx8 + 4*(SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
-                    bufx8 + 5*(SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
-                    bufx8 + 6*(SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
-                    bufx8 + 7*(SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
-                    SPX_SHA256_ADDR_BYTES + inblocks*SPX_N);
+    sha256x8_seeded(
+        /* out */
+        outbufx8 + 0*SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + 1*SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + 2*SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + 3*SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + 4*SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + 5*SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + 6*SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + 7*SPX_SHA256_OUTPUT_BYTES,
 
-    sha256_final8x(&ctx,
-                   outbufx8 + 0*SPX_SHA256_OUTPUT_BYTES,
-                   outbufx8 + 1*SPX_SHA256_OUTPUT_BYTES,
-                   outbufx8 + 2*SPX_SHA256_OUTPUT_BYTES,
-                   outbufx8 + 3*SPX_SHA256_OUTPUT_BYTES,
-                   outbufx8 + 4*SPX_SHA256_OUTPUT_BYTES,
-                   outbufx8 + 5*SPX_SHA256_OUTPUT_BYTES,
-                   outbufx8 + 6*SPX_SHA256_OUTPUT_BYTES,
-                   outbufx8 + 7*SPX_SHA256_OUTPUT_BYTES);
+        /* seed */
+        state_seeded, 512,
+
+        /* in */
+        bufx8 + 0*(SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
+        bufx8 + 1*(SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
+        bufx8 + 2*(SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
+        bufx8 + 3*(SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
+        bufx8 + 4*(SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
+        bufx8 + 5*(SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
+        bufx8 + 6*(SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
+        bufx8 + 7*(SPX_SHA256_ADDR_BYTES + inblocks*SPX_N),
+        SPX_SHA256_ADDR_BYTES + inblocks*SPX_N /* len */
+    );
 
     memcpy(out0, outbufx8 + 0*SPX_SHA256_OUTPUT_BYTES, SPX_N);
     memcpy(out1, outbufx8 + 1*SPX_SHA256_OUTPUT_BYTES, SPX_N);


### PR DESCRIPTION
I noticed a bug in `sha256_update8x` (which isn't hit.)  Instead of fixing it, I think it's better not to use a streaming API at all. So I simplified to just `sha256x8` and `sha256x8_seeded`.  This also allows to remove some memcpy's. (Cf. #1 )

Yields a ~7% speed-up.

Old:

```
Parameters: n = 32, h = 64, d = 8, b = 14, k = 22, w = 16
Running 10 iterations.
Generating keypair.. avg.    72649.16 us (0.07 sec); median    260,082,580 cycles,      1x:    260,082,580 cycles
  - WOTS pk gen 8x.. avg.     2271.23 us (0.00 sec); median      8,151,283 cycles,     32x:    260,841,056 cycles
Signing..            avg.   852742.20 us (0.85 sec); median  3,061,426,054 cycles,      1x:  3,061,426,054 cycles
  - FORS signing..   avg.   271187.83 us (0.27 sec); median    972,758,629 cycles,      1x:    972,758,629 cycles
  - WOTS pk gen x8.. avg.     2298.82 us (0.00 sec); median      8,272,768 cycles,    256x:  2,117,828,608 cycles
Verifying..          avg.     2028.46 us (0.00 sec); median      7,285,438 cycles,      1x:      7,285,438 cycles
```

New:

```
Parameters: n = 32, h = 64, d = 8, b = 14, k = 22, w = 16
Running 10 iterations.
Generating keypair.. avg.    68601.78 us (0.07 sec); median    245,590,489 cycles,      1x:    245,590,489 cycles
  - WOTS pk gen 8x.. avg.     2123.27 us (0.00 sec); median      7,619,943 cycles,     32x:    243,838,176 cycles
Signing..            avg.   800610.23 us (0.80 sec); median  2,875,063,056 cycles,      1x:  2,875,063,056 cycles
  - FORS signing..   avg.   254682.78 us (0.25 sec); median    914,055,381 cycles,      1x:    914,055,381 cycles
  - WOTS pk gen x8.. avg.     2117.12 us (0.00 sec); median      7,576,519 cycles,    256x:  1,939,588,864 cycles
Verifying..          avg.     1940.87 us (0.00 sec); median      6,923,338 cycles,      1x:      6,923,338 cycles
```