### PR TITLE
Counter long message

### DIFF
--- a/ref/Makefile
+++ b/ref/Makefile
@@ -1,8 +1,8 @@
 PARAMS = sphincs-shake256-128f
 THASH = robust
 
-CC = /usr/bin/gcc
-CFLAGS = -Wall -Wextra -Wpedantic -O3 -std=c99 -DPARAMS=$(PARAMS)
+CC=/usr/bin/gcc
+CFLAGS=-Wall -Wextra -Wpedantic -O3 -std=c99 -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
 
 SOURCES =          address.c randombytes.c merkle.c wots.c wotsx1.c utils.c utilsx1.c fors.c sign.c
 HEADERS = params.h address.h randombytes.h merkle.h wots.h wotsx1.h utils.h utilsx1.h fors.h api.h  hash.h thash.h

--- a/ref/hash_sha256.c
+++ b/ref/hash_sha256.c
@@ -40,12 +40,12 @@ void prf_addr(unsigned char *out, const unsigned char *key,
               const uint32_t addr[8])
 {
     unsigned char buf[SPX_N + SPX_SHA256_ADDR_BYTES];
-    unsigned char outbuf[SPX_SHAX_OUTPUT_BYTES];
+    unsigned char outbuf[SPX_SHA256_OUTPUT_BYTES];
 
     memcpy(buf, key, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_SHA256_ADDR_BYTES);
 
-    shaX(outbuf, buf, SPX_N + SPX_SHA256_ADDR_BYTES);
+    sha256(outbuf, buf, SPX_N + SPX_SHA256_ADDR_BYTES);
     memcpy(out, outbuf, SPX_N);
 }
 

--- a/ref/hash_sha256.c
+++ b/ref/hash_sha256.c
@@ -143,7 +143,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
     /* If R + pk + message cannot fill up an entire block */
     if (SPX_N + SPX_PK_BYTES + mlen < SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES) {
         memcpy(inbuf + SPX_N + SPX_PK_BYTES, m, mlen);
-        shaX_inc_finalize(seed, state, inbuf, SPX_N + SPX_PK_BYTES + mlen);
+        shaX_inc_finalize(seed + 2*SPX_N, state, inbuf, SPX_N + SPX_PK_BYTES + mlen);
     }
     /* Otherwise first fill a block, so that finalize only uses the message */
     else {

--- a/ref/hash_sha256.c
+++ b/ref/hash_sha256.c
@@ -7,7 +7,24 @@
 #include "hash.h"
 #include "sha256.h"
 
-/* For SHA256, there is no immediate reason to initialize at the start,
+#if SPX_N==32
+#define SPX_SHAX_OUTPUT_BYTES (SPX_SHA256_OUTPUT_BYTES*2)
+#define SPX_SHAX_BLOCK_BYTES (SPX_SHA256_BLOCK_BYTES*2)
+#define shaX_inc_init sha512_inc_init
+#define shaX_inc_blocks sha512_inc_blocks
+#define shaX_inc_finalize sha512_inc_finalize
+#define shaX sha512
+#else
+#define SPX_SHAX_OUTPUT_BYTES SPX_SHA256_OUTPUT_BYTES
+#define SPX_SHAX_BLOCK_BYTES SPX_SHA256_BLOCK_BYTES
+#define shaX_inc_init sha256_inc_init
+#define shaX_inc_blocks sha256_inc_blocks
+#define shaX_inc_finalize sha256_inc_finalize
+#define shaX sha256
+#endif
+
+
+/* For SHA, there is no immediate reason to initialize at the start,
    so this function is an empty operation. */
 void initialize_hash_function(const unsigned char *pub_seed,
                               const unsigned char *sk_seed)
@@ -23,19 +40,19 @@ void prf_addr(unsigned char *out, const unsigned char *key,
               const uint32_t addr[8])
 {
     unsigned char buf[SPX_N + SPX_SHA256_ADDR_BYTES];
-    unsigned char outbuf[SPX_SHA256_OUTPUT_BYTES];
+    unsigned char outbuf[SPX_SHAX_OUTPUT_BYTES];
 
     memcpy(buf, key, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_SHA256_ADDR_BYTES);
 
-    sha256(outbuf, buf, SPX_N + SPX_SHA256_ADDR_BYTES);
+    shaX(outbuf, buf, SPX_N + SPX_SHA256_ADDR_BYTES);
     memcpy(out, outbuf, SPX_N);
 }
 
 /**
  * Computes the message-dependent randomness R, using a secret seed as a key
  * for HMAC, and an optional randomization value prefixed to the message.
- * This requires m to have at least SPX_SHA256_BLOCK_BYTES + SPX_N space
+ * This requires m to have at least SPX_SHAX_BLOCK_BYTES + SPX_N space
  * available in front of the pointer, i.e. before the message to use for the
  * prefix. This is necessary to prevent having to move the message around (and
  * allocate memory for it).
@@ -44,47 +61,47 @@ void gen_message_random(unsigned char *R, const unsigned char *sk_prf,
                         const unsigned char *optrand,
                         const unsigned char *m, unsigned long long mlen)
 {
-    unsigned char buf[SPX_SHA256_BLOCK_BYTES + SPX_SHA256_OUTPUT_BYTES];
+    unsigned char buf[SPX_SHAX_BLOCK_BYTES + SPX_SHAX_OUTPUT_BYTES];
     uint8_t state[40];
     int i;
 
-#if SPX_N > SPX_SHA256_BLOCK_BYTES
-    #error "Currently only supports SPX_N of at most SPX_SHA256_BLOCK_BYTES"
+#if SPX_N > SPX_SHAX_BLOCK_BYTES
+    #error "Currently only supports SPX_N of at most SPX_SHAX_BLOCK_BYTES"
 #endif
 
-    /* This implements HMAC-SHA256 */
+    /* This implements HMAC-SHA */
     for (i = 0; i < SPX_N; i++) {
         buf[i] = 0x36 ^ sk_prf[i];
     }
-    memset(buf + SPX_N, 0x36, SPX_SHA256_BLOCK_BYTES - SPX_N);
+    memset(buf + SPX_N, 0x36, SPX_SHAX_BLOCK_BYTES - SPX_N);
 
-    sha256_inc_init(state);
-    sha256_inc_blocks(state, buf, 1);
+    shaX_inc_init(state);
+    shaX_inc_blocks(state, buf, 1);
 
     memcpy(buf, optrand, SPX_N);
 
     /* If optrand + message cannot fill up an entire block */
-    if (SPX_N + mlen < SPX_SHA256_BLOCK_BYTES) {
+    if (SPX_N + mlen < SPX_SHAX_BLOCK_BYTES) {
         memcpy(buf + SPX_N, m, mlen);
-        sha256_inc_finalize(buf + SPX_SHA256_BLOCK_BYTES, state,
+        shaX_inc_finalize(buf + SPX_SHAX_BLOCK_BYTES, state,
                             buf, mlen + SPX_N);
     }
     /* Otherwise first fill a block, so that finalize only uses the message */
     else {
-        memcpy(buf + SPX_N, m, SPX_SHA256_BLOCK_BYTES - SPX_N);
-        sha256_inc_blocks(state, buf, 1);
+        memcpy(buf + SPX_N, m, SPX_SHAX_BLOCK_BYTES - SPX_N);
+        shaX_inc_blocks(state, buf, 1);
 
-        m += SPX_SHA256_BLOCK_BYTES - SPX_N;
-        mlen -= SPX_SHA256_BLOCK_BYTES - SPX_N;
-        sha256_inc_finalize(buf + SPX_SHA256_BLOCK_BYTES, state, m, mlen);
+        m += SPX_SHAX_BLOCK_BYTES - SPX_N;
+        mlen -= SPX_SHAX_BLOCK_BYTES - SPX_N;
+        shaX_inc_finalize(buf + SPX_SHAX_BLOCK_BYTES, state, m, mlen);
     }
 
     for (i = 0; i < SPX_N; i++) {
         buf[i] = 0x5c ^ sk_prf[i];
     }
-    memset(buf + SPX_N, 0x5c, SPX_SHA256_BLOCK_BYTES - SPX_N);
+    memset(buf + SPX_N, 0x5c, SPX_SHAX_BLOCK_BYTES - SPX_N);
 
-    sha256(buf, buf, SPX_SHA256_BLOCK_BYTES + SPX_SHA256_OUTPUT_BYTES);
+    shaX(buf, buf, SPX_SHAX_BLOCK_BYTES + SPX_SHAX_OUTPUT_BYTES);
     memcpy(R, buf, SPX_N);
 }
 
@@ -103,40 +120,40 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 #define SPX_LEAF_BYTES ((SPX_LEAF_BITS + 7) / 8)
 #define SPX_DGST_BYTES (SPX_FORS_MSG_BYTES + SPX_TREE_BYTES + SPX_LEAF_BYTES)
 
-    unsigned char seed[2*SPX_N + SPX_SHA256_OUTPUT_BYTES];
+    unsigned char seed[2*SPX_N + SPX_SHAX_OUTPUT_BYTES];
 
-    /* Round to nearest multiple of SPX_SHA256_BLOCK_BYTES */
-#if (SPX_SHA256_BLOCK_BYTES & (SPX_SHA256_BLOCK_BYTES-1)) != 0
-    #error "Assumes that SPX_SHA256_BLOCK_BYTES is a power of 2"
+    /* Round to nearest multiple of SPX_SHAX_BLOCK_BYTES */
+#if (SPX_SHAX_BLOCK_BYTES & (SPX_SHAX_BLOCK_BYTES-1)) != 0
+    #error "Assumes that SPX_SHAX_BLOCK_BYTES is a power of 2"
 #endif
-#define SPX_INBLOCKS (((SPX_N + SPX_PK_BYTES + SPX_SHA256_BLOCK_BYTES - 1) & \
-                        -SPX_SHA256_BLOCK_BYTES) / SPX_SHA256_BLOCK_BYTES)
-    unsigned char inbuf[SPX_INBLOCKS * SPX_SHA256_BLOCK_BYTES];
+#define SPX_INBLOCKS (((SPX_N + SPX_PK_BYTES + SPX_SHAX_BLOCK_BYTES - 1) & \
+                        -SPX_SHAX_BLOCK_BYTES) / SPX_SHAX_BLOCK_BYTES)
+    unsigned char inbuf[SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES];
 
     unsigned char buf[SPX_DGST_BYTES];
     unsigned char *bufp = buf;
     uint8_t state[40];
 
-    sha256_inc_init(state);
+    shaX_inc_init(state);
 
     // seed: SHA-256(R || PK.seed || PK.root || M)
     memcpy(inbuf, R, SPX_N);
     memcpy(inbuf + SPX_N, pk, SPX_PK_BYTES);
 
     /* If R + pk + message cannot fill up an entire block */
-    if (SPX_N + SPX_PK_BYTES + mlen < SPX_INBLOCKS * SPX_SHA256_BLOCK_BYTES) {
+    if (SPX_N + SPX_PK_BYTES + mlen < SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES) {
         memcpy(inbuf + SPX_N + SPX_PK_BYTES, m, mlen);
-        sha256_inc_finalize(seed, state, inbuf, SPX_N + SPX_PK_BYTES + mlen);
+        shaX_inc_finalize(seed, state, inbuf, SPX_N + SPX_PK_BYTES + mlen);
     }
     /* Otherwise first fill a block, so that finalize only uses the message */
     else {
         memcpy(inbuf + SPX_N + SPX_PK_BYTES, m,
-               SPX_INBLOCKS * SPX_SHA256_BLOCK_BYTES - SPX_N - SPX_PK_BYTES);
-        sha256_inc_blocks(state, inbuf, SPX_INBLOCKS);
+               SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES - SPX_N - SPX_PK_BYTES);
+        shaX_inc_blocks(state, inbuf, SPX_INBLOCKS);
 
-        m += SPX_INBLOCKS * SPX_SHA256_BLOCK_BYTES - SPX_N - SPX_PK_BYTES;
-        mlen -= SPX_INBLOCKS * SPX_SHA256_BLOCK_BYTES - SPX_N - SPX_PK_BYTES;
-        sha256_inc_finalize(seed + 2*SPX_N, state, m, mlen);
+        m += SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES - SPX_N - SPX_PK_BYTES;
+        mlen -= SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES - SPX_N - SPX_PK_BYTES;
+        shaX_inc_finalize(seed + 2*SPX_N, state, m, mlen);
     }
 
     // H_msg: MGF1-SHA-256(R || PK.seed || seed)
@@ -145,7 +162,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     /* By doing this in two steps, we prevent hashing the message twice;
        otherwise each iteration in MGF1 would hash the message again. */
-    mgf1(bufp, SPX_DGST_BYTES, seed, 2*SPX_N + SPX_SHA256_OUTPUT_BYTES);
+    mgf1(bufp, SPX_DGST_BYTES, seed, 2*SPX_N + SPX_SHAX_OUTPUT_BYTES);
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;

--- a/ref/hash_sha256.c
+++ b/ref/hash_sha256.c
@@ -62,7 +62,7 @@ void gen_message_random(unsigned char *R, const unsigned char *sk_prf,
                         const unsigned char *m, unsigned long long mlen)
 {
     unsigned char buf[SPX_SHAX_BLOCK_BYTES + SPX_SHAX_OUTPUT_BYTES];
-    uint8_t state[40];
+    uint8_t state[8 + SPX_SHAX_OUTPUT_BYTES];
     int i;
 
 #if SPX_N > SPX_SHAX_BLOCK_BYTES
@@ -132,7 +132,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     unsigned char buf[SPX_DGST_BYTES];
     unsigned char *bufp = buf;
-    uint8_t state[40];
+    uint8_t state[8 + SPX_SHAX_OUTPUT_BYTES];
 
     shaX_inc_init(state);
 

--- a/ref/hash_sha256.c
+++ b/ref/hash_sha256.c
@@ -8,8 +8,8 @@
 #include "sha256.h"
 
 #if SPX_N==32
-#define SPX_SHAX_OUTPUT_BYTES (SPX_SHA256_OUTPUT_BYTES*2)
-#define SPX_SHAX_BLOCK_BYTES (SPX_SHA256_BLOCK_BYTES*2)
+#define SPX_SHAX_OUTPUT_BYTES SPX_SHA512_OUTPUT_BYTES
+#define SPX_SHAX_BLOCK_BYTES SPX_SHA512_BLOCK_BYTES
 #define shaX_inc_init sha512_inc_init
 #define shaX_inc_blocks sha512_inc_blocks
 #define shaX_inc_finalize sha512_inc_finalize

--- a/ref/sha256.c
+++ b/ref/sha256.c
@@ -51,7 +51,7 @@ static void store_bigendian_64(uint8_t *x, uint64_t u) {
 
 #define SHR(x, c) ((x) >> (c))
 #define ROTR_32(x, c) (((x) >> (c)) | ((x) << (32 - (c))))
-#define ROTR_64(x, c) (((x) >> (c)) | ((x) << (64 - (c))))
+#define ROTR_64(x,c) (((x) >> (c)) | ((x) << (64 - (c))))
 
 #define Ch(x, y, z) (((x) & (y)) ^ (~(x) & (z)))
 #define Maj(x, y, z) (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
@@ -61,7 +61,13 @@ static void store_bigendian_64(uint8_t *x, uint64_t u) {
 #define sigma0_32(x) (ROTR_32(x, 7) ^ ROTR_32(x,18) ^ SHR(x, 3))
 #define sigma1_32(x) (ROTR_32(x,17) ^ ROTR_32(x,19) ^ SHR(x,10))
 
+#define Sigma0_64(x) (ROTR_64(x,28) ^ ROTR_64(x,34) ^ ROTR_64(x,39))
+#define Sigma1_64(x) (ROTR_64(x,14) ^ ROTR_64(x,18) ^ ROTR_64(x,41))
+#define sigma0_64(x) (ROTR_64(x, 1) ^ ROTR_64(x, 8) ^ SHR(x,7))
+#define sigma1_64(x) (ROTR_64(x,19) ^ ROTR_64(x,61) ^ SHR(x,6))
+
 #define M_32(w0, w14, w9, w1) w0 = sigma1_32(w14) + (w9) + sigma0_32(w1) + (w0);
+#define M_64(w0, w14, w9, w1) w0 = sigma1_64(w14) + (w9) + sigma0_64(w1) + (w0);
 
 #define EXPAND_32           \
     M_32(w0, w14, w9, w1)   \
@@ -81,6 +87,24 @@ static void store_bigendian_64(uint8_t *x, uint64_t u) {
     M_32(w14, w12, w7, w15) \
     M_32(w15, w13, w8, w0)
 
+#define EXPAND_64 \
+  M_64(w0 ,w14,w9 ,w1 ) \
+  M_64(w1 ,w15,w10,w2 ) \
+  M_64(w2 ,w0 ,w11,w3 ) \
+  M_64(w3 ,w1 ,w12,w4 ) \
+  M_64(w4 ,w2 ,w13,w5 ) \
+  M_64(w5 ,w3 ,w14,w6 ) \
+  M_64(w6 ,w4 ,w15,w7 ) \
+  M_64(w7 ,w5 ,w0 ,w8 ) \
+  M_64(w8 ,w6 ,w1 ,w9 ) \
+  M_64(w9 ,w7 ,w2 ,w10) \
+  M_64(w10,w8 ,w3 ,w11) \
+  M_64(w11,w9 ,w4 ,w12) \
+  M_64(w12,w10,w5 ,w13) \
+  M_64(w13,w11,w6 ,w14) \
+  M_64(w14,w12,w7 ,w15) \
+  M_64(w15,w13,w8 ,w0 )
+
 #define F_32(w, k)                                   \
     T1 = h + Sigma1_32(e) + Ch(e, f, g) + (k) + (w); \
     T2 = Sigma0_32(a) + Maj(a, b, c);                \
@@ -91,6 +115,18 @@ static void store_bigendian_64(uint8_t *x, uint64_t u) {
     d = c;                                           \
     c = b;                                           \
     b = a;                                           \
+    a = T1 + T2;
+
+#define F_64(w,k) \
+    T1 = h + Sigma1_64(e) + Ch(e,f,g) + k + w; \
+    T2 = Sigma0_64(a) + Maj(a,b,c); \
+    h = g; \
+    g = f; \
+    f = e; \
+    e = d + T1; \
+    d = c; \
+    c = b; \
+    b = a; \
     a = T1 + T2;
 
 static size_t crypto_hashblocks_sha256(uint8_t *statebytes,
@@ -250,11 +286,189 @@ static size_t crypto_hashblocks_sha256(uint8_t *statebytes,
     return inlen;
 }
 
+int crypto_hashblocks_sha512(unsigned char *statebytes,const unsigned char *in,unsigned long long inlen)
+{
+  uint64_t state[8];
+  uint64_t a;
+  uint64_t b;
+  uint64_t c;
+  uint64_t d;
+  uint64_t e;
+  uint64_t f;
+  uint64_t g;
+  uint64_t h;
+  uint64_t T1;
+  uint64_t T2;
+
+  a = load_bigendian_64(statebytes +  0); state[0] = a;
+  b = load_bigendian_64(statebytes +  8); state[1] = b;
+  c = load_bigendian_64(statebytes + 16); state[2] = c;
+  d = load_bigendian_64(statebytes + 24); state[3] = d;
+  e = load_bigendian_64(statebytes + 32); state[4] = e;
+  f = load_bigendian_64(statebytes + 40); state[5] = f;
+  g = load_bigendian_64(statebytes + 48); state[6] = g;
+  h = load_bigendian_64(statebytes + 56); state[7] = h;
+
+  while (inlen >= 128) {
+    uint64_t w0  = load_bigendian_64(in +   0);
+    uint64_t w1  = load_bigendian_64(in +   8);
+    uint64_t w2  = load_bigendian_64(in +  16);
+    uint64_t w3  = load_bigendian_64(in +  24);
+    uint64_t w4  = load_bigendian_64(in +  32);
+    uint64_t w5  = load_bigendian_64(in +  40);
+    uint64_t w6  = load_bigendian_64(in +  48);
+    uint64_t w7  = load_bigendian_64(in +  56);
+    uint64_t w8  = load_bigendian_64(in +  64);
+    uint64_t w9  = load_bigendian_64(in +  72);
+    uint64_t w10 = load_bigendian_64(in +  80);
+    uint64_t w11 = load_bigendian_64(in +  88);
+    uint64_t w12 = load_bigendian_64(in +  96);
+    uint64_t w13 = load_bigendian_64(in + 104);
+    uint64_t w14 = load_bigendian_64(in + 112);
+    uint64_t w15 = load_bigendian_64(in + 120);
+
+    F_64(w0 ,0x428a2f98d728ae22ULL)
+    F_64(w1 ,0x7137449123ef65cdULL)
+    F_64(w2 ,0xb5c0fbcfec4d3b2fULL)
+    F_64(w3 ,0xe9b5dba58189dbbcULL)
+    F_64(w4 ,0x3956c25bf348b538ULL)
+    F_64(w5 ,0x59f111f1b605d019ULL)
+    F_64(w6 ,0x923f82a4af194f9bULL)
+    F_64(w7 ,0xab1c5ed5da6d8118ULL)
+    F_64(w8 ,0xd807aa98a3030242ULL)
+    F_64(w9 ,0x12835b0145706fbeULL)
+    F_64(w10,0x243185be4ee4b28cULL)
+    F_64(w11,0x550c7dc3d5ffb4e2ULL)
+    F_64(w12,0x72be5d74f27b896fULL)
+    F_64(w13,0x80deb1fe3b1696b1ULL)
+    F_64(w14,0x9bdc06a725c71235ULL)
+    F_64(w15,0xc19bf174cf692694ULL)
+
+    EXPAND_64
+
+    F_64(w0 ,0xe49b69c19ef14ad2ULL)
+    F_64(w1 ,0xefbe4786384f25e3ULL)
+    F_64(w2 ,0x0fc19dc68b8cd5b5ULL)
+    F_64(w3 ,0x240ca1cc77ac9c65ULL)
+    F_64(w4 ,0x2de92c6f592b0275ULL)
+    F_64(w5 ,0x4a7484aa6ea6e483ULL)
+    F_64(w6 ,0x5cb0a9dcbd41fbd4ULL)
+    F_64(w7 ,0x76f988da831153b5ULL)
+    F_64(w8 ,0x983e5152ee66dfabULL)
+    F_64(w9 ,0xa831c66d2db43210ULL)
+    F_64(w10,0xb00327c898fb213fULL)
+    F_64(w11,0xbf597fc7beef0ee4ULL)
+    F_64(w12,0xc6e00bf33da88fc2ULL)
+    F_64(w13,0xd5a79147930aa725ULL)
+    F_64(w14,0x06ca6351e003826fULL)
+    F_64(w15,0x142929670a0e6e70ULL)
+
+    EXPAND_64
+
+    F_64(w0 ,0x27b70a8546d22ffcULL)
+    F_64(w1 ,0x2e1b21385c26c926ULL)
+    F_64(w2 ,0x4d2c6dfc5ac42aedULL)
+    F_64(w3 ,0x53380d139d95b3dfULL)
+    F_64(w4 ,0x650a73548baf63deULL)
+    F_64(w5 ,0x766a0abb3c77b2a8ULL)
+    F_64(w6 ,0x81c2c92e47edaee6ULL)
+    F_64(w7 ,0x92722c851482353bULL)
+    F_64(w8 ,0xa2bfe8a14cf10364ULL)
+    F_64(w9 ,0xa81a664bbc423001ULL)
+    F_64(w10,0xc24b8b70d0f89791ULL)
+    F_64(w11,0xc76c51a30654be30ULL)
+    F_64(w12,0xd192e819d6ef5218ULL)
+    F_64(w13,0xd69906245565a910ULL)
+    F_64(w14,0xf40e35855771202aULL)
+    F_64(w15,0x106aa07032bbd1b8ULL)
+
+    EXPAND_64
+
+    F_64(w0 ,0x19a4c116b8d2d0c8ULL)
+    F_64(w1 ,0x1e376c085141ab53ULL)
+    F_64(w2 ,0x2748774cdf8eeb99ULL)
+    F_64(w3 ,0x34b0bcb5e19b48a8ULL)
+    F_64(w4 ,0x391c0cb3c5c95a63ULL)
+    F_64(w5 ,0x4ed8aa4ae3418acbULL)
+    F_64(w6 ,0x5b9cca4f7763e373ULL)
+    F_64(w7 ,0x682e6ff3d6b2b8a3ULL)
+    F_64(w8 ,0x748f82ee5defb2fcULL)
+    F_64(w9 ,0x78a5636f43172f60ULL)
+    F_64(w10,0x84c87814a1f0ab72ULL)
+    F_64(w11,0x8cc702081a6439ecULL)
+    F_64(w12,0x90befffa23631e28ULL)
+    F_64(w13,0xa4506cebde82bde9ULL)
+    F_64(w14,0xbef9a3f7b2c67915ULL)
+    F_64(w15,0xc67178f2e372532bULL)
+
+    EXPAND_64
+
+    F_64(w0 ,0xca273eceea26619cULL)
+    F_64(w1 ,0xd186b8c721c0c207ULL)
+    F_64(w2 ,0xeada7dd6cde0eb1eULL)
+    F_64(w3 ,0xf57d4f7fee6ed178ULL)
+    F_64(w4 ,0x06f067aa72176fbaULL)
+    F_64(w5 ,0x0a637dc5a2c898a6ULL)
+    F_64(w6 ,0x113f9804bef90daeULL)
+    F_64(w7 ,0x1b710b35131c471bULL)
+    F_64(w8 ,0x28db77f523047d84ULL)
+    F_64(w9 ,0x32caab7b40c72493ULL)
+    F_64(w10,0x3c9ebe0a15c9bebcULL)
+    F_64(w11,0x431d67c49c100d4cULL)
+    F_64(w12,0x4cc5d4becb3e42b6ULL)
+    F_64(w13,0x597f299cfc657e2aULL)
+    F_64(w14,0x5fcb6fab3ad6faecULL)
+    F_64(w15,0x6c44198c4a475817ULL)
+
+    a += state[0];
+    b += state[1];
+    c += state[2];
+    d += state[3];
+    e += state[4];
+    f += state[5];
+    g += state[6];
+    h += state[7];
+  
+    state[0] = a;
+    state[1] = b;
+    state[2] = c;
+    state[3] = d;
+    state[4] = e;
+    state[5] = f;
+    state[6] = g;
+    state[7] = h;
+
+    in += 128;
+    inlen -= 128;
+  }
+
+  store_bigendian_64(statebytes +  0,state[0]);
+  store_bigendian_64(statebytes +  8,state[1]);
+  store_bigendian_64(statebytes + 16,state[2]);
+  store_bigendian_64(statebytes + 24,state[3]);
+  store_bigendian_64(statebytes + 32,state[4]);
+  store_bigendian_64(statebytes + 40,state[5]);
+  store_bigendian_64(statebytes + 48,state[6]);
+  store_bigendian_64(statebytes + 56,state[7]);
+
+  return inlen;
+}
+
+
 static const uint8_t iv_256[32] = {
     0x6a, 0x09, 0xe6, 0x67, 0xbb, 0x67, 0xae, 0x85,
     0x3c, 0x6e, 0xf3, 0x72, 0xa5, 0x4f, 0xf5, 0x3a,
     0x51, 0x0e, 0x52, 0x7f, 0x9b, 0x05, 0x68, 0x8c,
     0x1f, 0x83, 0xd9, 0xab, 0x5b, 0xe0, 0xcd, 0x19
+};
+
+static const uint8_t iv_512[64] = {
+    0x6a, 0x09, 0xe6, 0x67, 0xf3, 0xbc, 0xc9, 0x08, 0xbb, 0x67, 0xae,
+    0x85, 0x84, 0xca, 0xa7, 0x3b, 0x3c, 0x6e, 0xf3, 0x72, 0xfe, 0x94,
+    0xf8, 0x2b, 0xa5, 0x4f, 0xf5, 0x3a, 0x5f, 0x1d, 0x36, 0xf1, 0x51,
+    0x0e, 0x52, 0x7f, 0xad, 0xe6, 0x82, 0xd1, 0x9b, 0x05, 0x68, 0x8c,
+    0x2b, 0x3e, 0x6c, 0x1f, 0x1f, 0x83, 0xd9, 0xab, 0xfb, 0x41, 0xbd,
+    0x6b, 0x5b, 0xe0, 0xcd, 0x19, 0x13, 0x7e, 0x21, 0x79
 };
 
 void sha256_inc_init(uint8_t *state) {
@@ -266,6 +480,15 @@ void sha256_inc_init(uint8_t *state) {
     }
 }
 
+void sha512_inc_init(uint8_t *state) {
+    for (size_t i = 0; i < 64; ++i) {
+        state[i] = iv_512[i];
+    }
+    for (size_t i = 64; i < 72; ++i) {
+        state[i] = 0;
+    }
+}
+
 void sha256_inc_blocks(uint8_t *state, const uint8_t *in, size_t inblocks) {
     uint64_t bytes = load_bigendian_64(state + 32);
 
@@ -273,6 +496,15 @@ void sha256_inc_blocks(uint8_t *state, const uint8_t *in, size_t inblocks) {
     bytes += 64 * inblocks;
 
     store_bigendian_64(state + 32, bytes);
+}
+
+void sha512_inc_blocks(uint8_t *state, const uint8_t *in, size_t inblocks) {
+    uint64_t bytes = load_bigendian_64(state + 64);
+
+    crypto_hashblocks_sha512(state, in, 128 * inblocks);
+    bytes += 128 * inblocks;
+
+    store_bigendian_64(state + 64, bytes);
 }
 
 void sha256_inc_finalize(uint8_t *out, uint8_t *state, const uint8_t *in, size_t inlen) {
@@ -320,6 +552,56 @@ void sha256_inc_finalize(uint8_t *out, uint8_t *state, const uint8_t *in, size_t
     for (size_t i = 0; i < 32; ++i) {
         out[i] = state[i];
     }
+
+}
+
+void sha512_inc_finalize(uint8_t *out, uint8_t *state, const uint8_t *in, size_t inlen) {
+    uint8_t padded[256];
+    uint64_t bytes = load_bigendian_64(state + 64) + inlen;
+
+    crypto_hashblocks_sha512(state, in, inlen);
+    in += inlen;
+    inlen &= 127;
+    in -= inlen;
+
+    for (size_t i = 0; i < inlen; ++i) {
+        padded[i] = in[i];
+    }
+    padded[inlen] = 0x80;
+
+    if (inlen < 112) {
+        for (size_t i = inlen + 1; i < 119; ++i) {
+            padded[i] = 0;
+        }
+        padded[119] = (uint8_t) (bytes >> 61);
+        padded[120] = (uint8_t) (bytes >> 53);
+        padded[121] = (uint8_t) (bytes >> 45);
+        padded[122] = (uint8_t) (bytes >> 37);
+        padded[123] = (uint8_t) (bytes >> 29);
+        padded[124] = (uint8_t) (bytes >> 21);
+        padded[125] = (uint8_t) (bytes >> 13);
+        padded[126] = (uint8_t) (bytes >> 5);
+        padded[127] = (uint8_t) (bytes << 3);
+        crypto_hashblocks_sha512(state, padded, 128);
+    } else {
+        for (size_t i = inlen + 1; i < 247; ++i) {
+            padded[i] = 0;
+        }
+        padded[247] = (uint8_t) (bytes >> 61);
+        padded[248] = (uint8_t) (bytes >> 53);
+        padded[249] = (uint8_t) (bytes >> 45);
+        padded[250] = (uint8_t) (bytes >> 37);
+        padded[251] = (uint8_t) (bytes >> 29);
+        padded[252] = (uint8_t) (bytes >> 21);
+        padded[253] = (uint8_t) (bytes >> 13);
+        padded[254] = (uint8_t) (bytes >> 5);
+        padded[255] = (uint8_t) (bytes << 3);
+        crypto_hashblocks_sha512(state, padded, 256);
+    }
+
+    for (size_t i = 0; i < 64; ++i) {
+        out[i] = state[i];
+    }
 }
 
 void sha256(uint8_t *out, const uint8_t *in, size_t inlen) {
@@ -327,6 +609,13 @@ void sha256(uint8_t *out, const uint8_t *in, size_t inlen) {
 
     sha256_inc_init(state);
     sha256_inc_finalize(out, state, in, inlen);
+}
+
+void sha512(uint8_t *out, const uint8_t *in, size_t inlen) {
+    uint8_t state[72];
+
+    sha512_inc_init(state);
+    sha512_inc_finalize(out, state, in, inlen);
 }
 
 /**

--- a/ref/sha256.c
+++ b/ref/sha256.c
@@ -618,34 +618,6 @@ void sha512(uint8_t *out, const uint8_t *in, size_t inlen) {
     sha512_inc_finalize(out, state, in, inlen);
 }
 
-/**
- * Note that inlen should be sufficiently small that it still allows for
- * an array to be allocated on the stack. Typically 'in' is merely a seed.
- * Outputs outlen number of bytes
- */
-void mgf1(unsigned char *out, unsigned long outlen,
-          const unsigned char *in, unsigned long inlen)
-{
-    unsigned char inbuf[inlen + 4];
-    unsigned char outbuf[SPX_SHA256_OUTPUT_BYTES];
-    unsigned long i;
-
-    memcpy(inbuf, in, inlen);
-
-    /* While we can fit in at least another full block of SHA256 output.. */
-    for (i = 0; (i+1)*SPX_SHA256_OUTPUT_BYTES <= outlen; i++) {
-        u32_to_bytes(inbuf + inlen, i);
-        sha256(out, inbuf, inlen + 4);
-        out += SPX_SHA256_OUTPUT_BYTES;
-    }
-    /* Until we cannot anymore, and we fill the remainder. */
-    if (outlen > i*SPX_SHA256_OUTPUT_BYTES) {
-        u32_to_bytes(inbuf + inlen, i);
-        sha256(outbuf, inbuf, inlen + 4);
-        memcpy(out, outbuf, outlen - i*SPX_SHA256_OUTPUT_BYTES);
-    }
-}
-
 uint8_t state_seeded[40];
 
 /**

--- a/ref/sha256.h
+++ b/ref/sha256.h
@@ -26,7 +26,10 @@ void sha512_inc_blocks(uint8_t *state, const uint8_t *in, size_t inblocks);
 void sha512_inc_finalize(uint8_t *out, uint8_t *state, const uint8_t *in, size_t inlen);
 void sha512(uint8_t *out, const uint8_t *in, size_t inlen);
 
-void mgf1(unsigned char *out, unsigned long outlen,
+void mgf1_256(unsigned char *out, unsigned long outlen,
+          const unsigned char *in, unsigned long inlen);
+
+void mgf1_512(unsigned char *out, unsigned long outlen,
           const unsigned char *in, unsigned long inlen);
 
 extern uint8_t state_seeded[40];

--- a/ref/sha256.h
+++ b/ref/sha256.h
@@ -4,6 +4,9 @@
 #define SPX_SHA256_BLOCK_BYTES 64
 #define SPX_SHA256_OUTPUT_BYTES 32  /* This does not necessarily equal SPX_N */
 
+#define SPX_SHA512_BLOCK_BYTES 128
+#define SPX_SHA512_OUTPUT_BYTES 64
+
 #if SPX_SHA256_OUTPUT_BYTES < SPX_N
     #error Linking against SHA-256 with N larger than 32 bytes is not supported
 #endif

--- a/ref/sha256.h
+++ b/ref/sha256.h
@@ -18,11 +18,17 @@ void sha256_inc_blocks(uint8_t *state, const uint8_t *in, size_t inblocks);
 void sha256_inc_finalize(uint8_t *out, uint8_t *state, const uint8_t *in, size_t inlen);
 void sha256(uint8_t *out, const uint8_t *in, size_t inlen);
 
+void sha512_inc_init(uint8_t *state);
+void sha512_inc_blocks(uint8_t *state, const uint8_t *in, size_t inblocks);
+void sha512_inc_finalize(uint8_t *out, uint8_t *state, const uint8_t *in, size_t inlen);
+void sha512(uint8_t *out, const uint8_t *in, size_t inlen);
+
 void mgf1(unsigned char *out, unsigned long outlen,
           const unsigned char *in, unsigned long inlen);
 
 extern uint8_t state_seeded[40];
 
 void seed_state(const unsigned char *pub_seed);
+
 
 #endif

--- a/ref/thash_sha256_robust.c
+++ b/ref/thash_sha256_robust.c
@@ -20,7 +20,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
 
     memcpy(buf, pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_SHA256_ADDR_BYTES);
-    mgf1(bitmask, inblocks * SPX_N, buf, SPX_N + SPX_SHA256_ADDR_BYTES);
+    mgf1_256(bitmask, inblocks * SPX_N, buf, SPX_N + SPX_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
     memcpy(sha2_state, state_seeded, 40 * sizeof(uint8_t));


### PR DESCRIPTION
Implementing countermeasures for second preimage attacks as discussed in NIST's Third PQC Standardization Conference.