### PR TITLE
Fix missing prototypes

### DIFF
--- a/haraka-aesni/Makefile
+++ b/haraka-aesni/Makefile
@@ -2,7 +2,7 @@ PARAMS = sphincs-haraka-128f
 THASH = robust
 
 CC = /usr/bin/gcc
-CFLAGS = -Wall -Wextra -Wpedantic -O3 -std=c99 -march=native -fomit-frame-pointer -flto -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
+CFLAGS = -Wall -Wextra -Wpedantic -Wmissing-prototypes -O3 -std=c99 -march=native -fomit-frame-pointer -flto -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
 
 
 SOURCES = hash_haraka.c hash_harakax4.c thash_haraka_$(THASH).c thash_haraka_$(THASH)x4.c address.c randombytes.c merkle.c wots.c utils.c utilsx4.c fors.c sign.c haraka.c

--- a/haraka-aesni/haraka.c
+++ b/haraka-aesni/haraka.c
@@ -69,7 +69,7 @@ Plain C implementation of the Haraka256 and Haraka512 permutations.
   _mm_storeu_si128((u128 *)(out + 16), \
                    (__m128i)_mm_shuffle_pd((__m128d)s2, (__m128d)s3, 0));
 
-void load_haraka_constants(u128 *rc)
+static void load_haraka_constants(u128 *rc)
 {
     rc[0] = _mm_set_epi32(0x0684704c,0xe620c00a,0xb2c5fef0,0x75817b9d);
     rc[1] = _mm_set_epi32(0x8b66b4e1,0x88f3a06b,0x640f6ba4,0x2f08f717);

--- a/ref/Makefile
+++ b/ref/Makefile
@@ -2,7 +2,7 @@ PARAMS = sphincs-haraka-128f
 THASH = robust
 
 CC=/usr/bin/gcc
-CFLAGS=-Wall -Wextra -Wpedantic -O3 -std=c99 -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
+CFLAGS=-Wall -Wextra -Wpedantic -O3 -std=c99 -Wmissing-prototypes -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
 
 SOURCES =          address.c randombytes.c merkle.c wots.c wotsx1.c utils.c utilsx1.c fors.c sign.c
 HEADERS = params.h address.h randombytes.h merkle.h wots.h wotsx1.h utils.h utilsx1.h fors.h api.h  hash.h thash.h

--- a/ref/address.c
+++ b/ref/address.c
@@ -1,7 +1,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "params.h"
+#include "address.h"
 #include "utils.h"
 
 /*

--- a/ref/address.c
+++ b/ref/address.c
@@ -2,6 +2,7 @@
 #include <string.h>
 
 #include "address.h"
+#include "params.h"
 #include "utils.h"
 
 /*

--- a/ref/address.h
+++ b/ref/address.h
@@ -2,6 +2,7 @@
 #define SPX_ADDRESS_H
 
 #include <stdint.h>
+#include "params.h"
 
 /* The hash types that are passed to set_type */
 #define SPX_ADDR_TYPE_WOTS 0

--- a/ref/address.h
+++ b/ref/address.h
@@ -2,7 +2,6 @@
 #define SPX_ADDRESS_H
 
 #include <stdint.h>
-#include "params.h"
 
 /* The hash types that are passed to set_type */
 #define SPX_ADDR_TYPE_WOTS 0

--- a/ref/haraka.c
+++ b/ref/haraka.c
@@ -235,7 +235,7 @@ static void br_aes_ct64_bitslice_Sbox(uint64_t *q) {
     q[0] = s7;
 }
 
-void br_aes_ct_bitslice_Sbox(uint32_t *q)
+static void br_aes_ct_bitslice_Sbox(uint32_t *q)
 {
     /*
      * This S-box implementation is a straightforward translation of
@@ -410,7 +410,7 @@ void br_aes_ct_bitslice_Sbox(uint32_t *q)
     q[0] = s7;
 }
 
-void br_aes_ct_ortho(uint32_t *q) 
+static void br_aes_ct_ortho(uint32_t *q)
 {
 #define SWAPN_32(cl, ch, s, x, y)   do { \
         uint32_t a, b; \
@@ -653,7 +653,7 @@ static inline void mix_columns(uint64_t *q)
     q[7] = q6 ^ r6 ^ r7 ^ rotr32(q7 ^ r7);
 }
 
-void interleave_constant(uint64_t *out, const unsigned char *in) 
+static void interleave_constant(uint64_t *out, const unsigned char *in)
 {
     uint32_t tmp_32_constant[16];
     int i;
@@ -665,7 +665,7 @@ void interleave_constant(uint64_t *out, const unsigned char *in)
     br_aes_ct64_ortho(out);
 }
 
-void interleave_constant32(uint32_t *out, const unsigned char *in) 
+static void interleave_constant32(uint32_t *out, const unsigned char *in)
 {
     int i;
     for (i = 0; i < 4; i++) {

--- a/ref/rng.c
+++ b/ref/rng.c
@@ -102,7 +102,7 @@ seedexpander(AES_XOF_struct *ctx, unsigned char *x, unsigned long xlen)
 }
 
 
-void handleErrors(void)
+static void handleErrors(void)
 {
     ERR_print_errors_fp(stderr);
     abort();

--- a/sha2-avx2/Makefile
+++ b/sha2-avx2/Makefile
@@ -2,7 +2,7 @@ PARAMS = sphincs-sha2-128f
 THASH = robust
 
 CC = /usr/bin/gcc
-CFLAGS = -Wall -Wextra -Wpedantic -O3 -std=c99 -march=native -fomit-frame-pointer -flto -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
+CFLAGS = -Wall -Wextra -Wpedantic -Wmissing-prototypes -O3 -std=c99 -march=native -flto -fomit-frame-pointer -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
 
 
 SOURCES =          hash_sha2.c hash_sha2x8.c thash_sha2_$(THASH).c thash_sha2_$(THASH)x8.c sha2.c sha256x8.c sha512x4.c sha256avx.c address.c randombytes.c merkle.c wots.c utils.c utilsx8.c fors.c sign.c

--- a/sha2-avx2/sha512x4.c
+++ b/sha2-avx2/sha512x4.c
@@ -51,7 +51,7 @@ static void transpose(u256 s[4]) {
 }
 
 
-void sha512_init4x(sha512ctx4x *ctx) {
+static void sha512_init4x(sha512ctx4x *ctx) {
 #define SET4(x) _mm256_set_epi64x(x, x, x, x)
     ctx->s[0] = SET4(0x6a09e667f3bcc908ULL);
     ctx->s[1] = SET4(0xbb67ae8584caa73bULL);

--- a/sha2-avx2/utilsx8.c
+++ b/sha2-avx2/utilsx8.c
@@ -1,6 +1,7 @@
 #include <string.h>
 
 #include "utils.h"
+#include "utilsx8.h"
 #include "params.h"
 #include "thashx8.h"
 #include "address.h"

--- a/shake-a64/Makefile
+++ b/shake-a64/Makefile
@@ -1,7 +1,7 @@
 PARAMS = sphincs-shake-128f
 THASH = robust
 
-CFLAGS = -Wall -Wextra -Wpedantic -O3 -std=c99 -fomit-frame-pointer -flto -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
+CFLAGS = -Wall -Wextra -Wpedantic -Wmissing-prototypes -O3 -std=c99 -fomit-frame-pointer -flto -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
 
 SOURCES =          hash_shake.c hash_shakex2.c thash_shake_$(THASH)x2.c address.c randombytes.c merkle.c wots.c utils.c utilsx2.c fors.c sign.c fips202.c fips202x2.c f1600x2.c f1600x2.s
 HEADERS = params.h hash.h          hashx2.h                          thashx2.h                 address.h randombytes.h merkle.h wots.h utils.h utilsx2.h fors.h api.h fips202.h fips202x2.h f1600x2.h thash.h

--- a/shake-a64/utilsx2.c
+++ b/shake-a64/utilsx2.c
@@ -1,6 +1,7 @@
 #include <string.h>
 
 #include "utils.h"
+#include "utilsx2.h"
 #include "params.h"
 #include "thashx2.h"
 #include "address.h"

--- a/shake-avx2/Makefile
+++ b/shake-avx2/Makefile
@@ -2,7 +2,7 @@ PARAMS = sphincs-shake-128f
 THASH = robust
 
 CC = /usr/bin/gcc
-CFLAGS = -Wall -Wextra -Wpedantic -O3 -std=c99 -march=native -fomit-frame-pointer -flto -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
+CFLAGS = -Wall -Wextra -Wpedantic -Wmissing-prototypes -O3 -std=c99 -march=native -fomit-frame-pointer -flto -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
 
 SOURCES =          hash_shake.c hash_shakex4.c thash_shake_$(THASH).c thash_shake_$(THASH)x4.c address.c randombytes.c merkle.c wots.c utils.c utilsx4.c fors.c sign.c fips202.c fips202x4.c keccak4x/KeccakP-1600-times4-SIMD256.o
 HEADERS = params.h hash.h          hashx4.h          thash.h                 thashx4.h                 address.h randombytes.h merkle.h wots.h utils.h utilsx4.h fors.h api.h fips202.h fips202x4.h

--- a/shake-avx2/fips202x4.c
+++ b/shake-avx2/fips202x4.c
@@ -1,7 +1,9 @@
 #include <immintrin.h>
 #include <stdint.h>
 #include <assert.h>
+
 #include "fips202.h"
+#include "fips202x4.h"
 
 #define NROUNDS 24
 #define ROL(a, offset) ((a << offset) ^ (a >> (64-offset)))

--- a/shake-avx2/utilsx4.c
+++ b/shake-avx2/utilsx4.c
@@ -1,6 +1,7 @@
 #include <string.h>
 
 #include "utils.h"
+#include "utilsx4.h"
 #include "params.h"
 #include "thashx4.h"
 #include "address.h"


### PR DESCRIPTION
Enables `-Wmissing-prototypes` and fixes the warnings that came up. PQClean requires this warning, and it's useful to find functions that should be marked `static`.

Someone with an Armv8 CPU at hand should double-check if the sha2-a64 changes were sufficient.