### PR TITLE
Namespace SPHINCS+ internals

### DIFF
--- a/haraka-aesni/Makefile
+++ b/haraka-aesni/Makefile
@@ -2,7 +2,7 @@ PARAMS = sphincs-haraka-128f
 THASH = robust
 
 CC = /usr/bin/gcc
-CFLAGS = -Wall -Wextra -Wpedantic -O3 -std=c99 -march=native -fomit-frame-pointer -flto -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
+CFLAGS = -Wall -Wextra -Wpedantic -Wmissing-prototypes -O3 -std=c99 -march=native -fomit-frame-pointer -flto -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
 
 
 SOURCES = hash_haraka.c hash_harakax4.c thash_haraka_$(THASH).c thash_haraka_$(THASH)x4.c address.c randombytes.c merkle.c wots.c utils.c utilsx4.c fors.c sign.c haraka.c

--- a/haraka-aesni/haraka.c
+++ b/haraka-aesni/haraka.c
@@ -69,7 +69,7 @@ Plain C implementation of the Haraka256 and Haraka512 permutations.
   _mm_storeu_si128((u128 *)(out + 16), \
                    (__m128i)_mm_shuffle_pd((__m128d)s2, (__m128d)s3, 0));
 
-void load_haraka_constants(u128 *rc)
+static void load_haraka_constants(u128 *rc)
 {
     rc[0] = _mm_set_epi32(0x0684704c,0xe620c00a,0xb2c5fef0,0x75817b9d);
     rc[1] = _mm_set_epi32(0x8b66b4e1,0x88f3a06b,0x640f6ba4,0x2f08f717);

--- a/haraka-aesni/harakax4.h
+++ b/haraka-aesni/harakax4.h
@@ -2,8 +2,10 @@
 #define SPX_HARAKAX4_H
 
 #include "context.h"
+#include "params.h"
 
 /* Haraka Sponge */
+#define haraka_Sx4 SPX_NAMESPACE(haraka_Sx4)
 void haraka_Sx4(unsigned char *out0,
                 unsigned char *out1,
                 unsigned char *out2,
@@ -17,14 +19,17 @@ void haraka_Sx4(unsigned char *out0,
                 const spx_ctx *ctx);
 
 /* Applies the 512-bit Haraka permutation x4 to in. */
+#define haraka512_perm_x4 SPX_NAMESPACE(haraka512_perm_x4)
 void haraka512_perm_x4(unsigned char *out, const unsigned char *in,
         const spx_ctx *ctx);
 
 /* Implementation of Haraka-512 x4*/
+#define haraka512x4 SPX_NAMESPACE(haraka512x4)
 void haraka512x4(unsigned char *out, const unsigned char *in,
         const spx_ctx *ctx);
 
 /* Implementation of Haraka-256 x4 */
+#define haraka256x4 SPX_NAMESPACE(haraka256x4)
 void haraka256x4(unsigned char *out, const unsigned char *in,
         const spx_ctx *ctx);
 

--- a/haraka-aesni/hash_harakax4.c
+++ b/haraka-aesni/hash_harakax4.c
@@ -9,6 +9,7 @@
 /*
  * 4-way parallel version of prf_addr; takes 4x as much input and output
  */
+#define prf_addrx4 SPX_NAMESPACE(prf_addrx4)
 void prf_addrx4(unsigned char *out0,
                 unsigned char *out1,
                 unsigned char *out2,

--- a/haraka-aesni/thash_haraka_robustx4.c
+++ b/haraka-aesni/thash_haraka_robustx4.c
@@ -10,6 +10,7 @@
 /**
  * 4-way parallel version of thash; takes 4x as much input and output
  */
+#define thashx4 SPX_NAMESPACE(thashx4)
 void thashx4(unsigned char *out0,
              unsigned char *out1,
              unsigned char *out2,

--- a/haraka-aesni/thash_haraka_simplex4.c
+++ b/haraka-aesni/thash_haraka_simplex4.c
@@ -10,6 +10,7 @@
 /**
  * 4-way parallel version of thash; takes 4x as much input and output
  */
+#define thashx4 SPX_NAMESPACE(thashx4)
 void thashx4(unsigned char *out0,
              unsigned char *out1,
              unsigned char *out2,

--- a/ref/Makefile
+++ b/ref/Makefile
@@ -2,7 +2,7 @@ PARAMS = sphincs-haraka-128f
 THASH = robust
 
 CC=/usr/bin/gcc
-CFLAGS=-Wall -Wextra -Wpedantic -O3 -std=c99 -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
+CFLAGS=-Wall -Wextra -Wpedantic -O3 -std=c99 -Wmissing-prototypes -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
 
 SOURCES =          address.c randombytes.c merkle.c wots.c wotsx1.c utils.c utilsx1.c fors.c sign.c
 HEADERS = params.h address.h randombytes.h merkle.h wots.h wotsx1.h utils.h utilsx1.h fors.h api.h  hash.h thash.h

--- a/ref/address.c
+++ b/ref/address.c
@@ -1,7 +1,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "params.h"
+#include "address.h"
 #include "utils.h"
 
 /*

--- a/ref/address.h
+++ b/ref/address.h
@@ -13,29 +13,39 @@
 #define SPX_ADDR_TYPE_WOTSPRF 5
 #define SPX_ADDR_TYPE_FORSPRF 6
 
+#define set_layer_addr SPX_NAMESPACE(set_layer_addr)
 void set_layer_addr(uint32_t addr[8], uint32_t layer);
 
+#define set_tree_addr SPX_NAMESPACE(set_tree_addr)
 void set_tree_addr(uint32_t addr[8], uint64_t tree);
 
+#define set_type SPX_NAMESPACE(set_type)
 void set_type(uint32_t addr[8], uint32_t type);
 
 /* Copies the layer and tree part of one address into the other */
+#define copy_subtree_addr SPX_NAMESPACE(copy_subtree_addr)
 void copy_subtree_addr(uint32_t out[8], const uint32_t in[8]);
 
 /* These functions are used for WOTS and FORS addresses. */
 
+#define set_keypair_addr SPX_NAMESPACE(set_keypair_addr)
 void set_keypair_addr(uint32_t addr[8], uint32_t keypair);
 
+#define set_chain_addr SPX_NAMESPACE(set_chain_addr)
 void set_chain_addr(uint32_t addr[8], uint32_t chain);
 
+#define set_hash_addr SPX_NAMESPACE(set_hash_addr)
 void set_hash_addr(uint32_t addr[8], uint32_t hash);
 
+#define copy_keypair_addr SPX_NAMESPACE(copy_keypair_addr)
 void copy_keypair_addr(uint32_t out[8], const uint32_t in[8]);
 
 /* These functions are used for all hash tree addresses (including FORS). */
 
+#define set_tree_height SPX_NAMESPACE(set_tree_height)
 void set_tree_height(uint32_t addr[8], uint32_t tree_height);
 
+#define set_tree_index SPX_NAMESPACE(set_tree_index)
 void set_tree_index(uint32_t addr[8], uint32_t tree_index);
 
 #endif

--- a/ref/address.h
+++ b/ref/address.h
@@ -2,6 +2,7 @@
 #define SPX_ADDRESS_H
 
 #include <stdint.h>
+#include "params.h"
 
 /* The hash types that are passed to set_type */
 #define SPX_ADDR_TYPE_WOTS 0

--- a/ref/fors.h
+++ b/ref/fors.h
@@ -10,6 +10,7 @@
  * Signs a message m, deriving the secret key from sk_seed and the FTS address.
  * Assumes m contains at least SPX_FORS_HEIGHT * SPX_FORS_TREES bits.
  */
+#define fors_sign SPX_NAMESPACE(fors_sign)
 void fors_sign(unsigned char *sig, unsigned char *pk,
                const unsigned char *m,
                const spx_ctx* ctx,
@@ -22,6 +23,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
  * typical use-case when used as an FTS below an OTS in a hypertree.
  * Assumes m contains at least SPX_FORS_HEIGHT * SPX_FORS_TREES bits.
  */
+#define fors_pk_from_sig SPX_NAMESPACE(fors_pk_from_sig)
 void fors_pk_from_sig(unsigned char *pk,
                       const unsigned char *sig, const unsigned char *m,
                       const spx_ctx* ctx,

--- a/ref/haraka.c
+++ b/ref/haraka.c
@@ -235,7 +235,7 @@ static void br_aes_ct64_bitslice_Sbox(uint64_t *q) {
     q[0] = s7;
 }
 
-void br_aes_ct_bitslice_Sbox(uint32_t *q)
+static void br_aes_ct_bitslice_Sbox(uint32_t *q)
 {
     /*
      * This S-box implementation is a straightforward translation of
@@ -410,7 +410,7 @@ void br_aes_ct_bitslice_Sbox(uint32_t *q)
     q[0] = s7;
 }
 
-void br_aes_ct_ortho(uint32_t *q) 
+static void br_aes_ct_ortho(uint32_t *q)
 {
 #define SWAPN_32(cl, ch, s, x, y)   do { \
         uint32_t a, b; \
@@ -653,7 +653,7 @@ static inline void mix_columns(uint64_t *q)
     q[7] = q6 ^ r6 ^ r7 ^ rotr32(q7 ^ r7);
 }
 
-void interleave_constant(uint64_t *out, const unsigned char *in) 
+static void interleave_constant(uint64_t *out, const unsigned char *in)
 {
     uint32_t tmp_32_constant[16];
     int i;
@@ -665,7 +665,7 @@ void interleave_constant(uint64_t *out, const unsigned char *in)
     br_aes_ct64_ortho(out);
 }
 
-void interleave_constant32(uint32_t *out, const unsigned char *in) 
+static void interleave_constant32(uint32_t *out, const unsigned char *in)
 {
     int i;
     for (i = 0; i < 4; i++) {

--- a/ref/haraka.h
+++ b/ref/haraka.h
@@ -4,28 +4,37 @@
 #include "context.h"
 
 /* Tweak constants with seed */
+#define tweak_constants SPX_NAMESPACE(tweak_constants)
 void tweak_constants(spx_ctx *ctx);
 
 /* Haraka Sponge */
+#define haraka_S_inc_init SPX_NAMESPACE(haraka_S_inc_init)
 void haraka_S_inc_init(uint8_t *s_inc);
+#define haraka_S_inc_absorb SPX_NAMESPACE(haraka_S_inc_absorb)
 void haraka_S_inc_absorb(uint8_t *s_inc, const uint8_t *m, size_t mlen,
         const spx_ctx *ctx);
+#define haraka_S_inc_finalize SPX_NAMESPACE(haraka_S_inc_finalize)
 void haraka_S_inc_finalize(uint8_t *s_inc);
+#define haraka_S_inc_squeeze SPX_NAMESPACE(haraka_S_inc_squeeze)
 void haraka_S_inc_squeeze(uint8_t *out, size_t outlen, uint8_t *s_inc,
         const spx_ctx *ctx);
+#define haraka_S SPX_NAMESPACE(haraka_S)
 void haraka_S(unsigned char *out, unsigned long long outlen,
               const unsigned char *in, unsigned long long inlen,
               const spx_ctx *ctx);
 
 /* Applies the 512-bit Haraka permutation to in. */
+#define haraka512_perm SPX_NAMESPACE(haraka512_perm)
 void haraka512_perm(unsigned char *out, const unsigned char *in,
         const spx_ctx *ctx);
 
 /* Implementation of Haraka-512 */
+#define haraka512 SPX_NAMESPACE(haraka512)
 void haraka512(unsigned char *out, const unsigned char *in,
         const spx_ctx *ctx);
 
 /* Implementation of Haraka-256 */
+#define haraka256 SPX_NAMESPACE(haraka256)
 void haraka256(unsigned char *out, const unsigned char *in,
         const spx_ctx *ctx);
 

--- a/ref/hash.h
+++ b/ref/hash.h
@@ -3,17 +3,22 @@
 
 #include <stdint.h>
 #include "context.h"
+#include "params.h"
 
+#define initialize_hash_function SPX_NAMESPACE(initialize_hash_function)
 void initialize_hash_function(spx_ctx *ctx);
 
+#define prf_addr SPX_NAMESPACE(prf_addr)
 void prf_addr(unsigned char *out, const spx_ctx *ctx,
               const uint32_t addr[8]);
 
+#define gen_message_random SPX_NAMESPACE(gen_message_random)
 void gen_message_random(unsigned char *R, const unsigned char *sk_prf,
                         const unsigned char *optrand,
                         const unsigned char *m, unsigned long long mlen,
                         const spx_ctx *ctx);
 
+#define hash_message SPX_NAMESPACE(hash_message)
 void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *R, const unsigned char *pk,
                   const unsigned char *m, unsigned long long mlen,

--- a/ref/merkle.h
+++ b/ref/merkle.h
@@ -5,12 +5,14 @@
 
 /* Generate a Merkle signature (WOTS signature followed by the Merkle */
 /* authentication path) */
+#define merkle_sign SPX_NAMESPACE(merkle_sign)
 void merkle_sign(uint8_t *sig, unsigned char *root,
         const spx_ctx* ctx,
         uint32_t wots_addr[8], uint32_t tree_addr[8],
         uint32_t idx_leaf);
 
 /* Compute the root node of the top-most subtree. */
+#define merkle_gen_root SPX_NAMESPACE(merkle_gen_root)
 void merkle_gen_root(unsigned char *root, const spx_ctx* ctx);
 
 #endif /* MERKLE_H_ */

--- a/ref/params/params-sphincs-haraka-128f.h
+++ b/ref/params/params-sphincs-haraka-128f.h
@@ -1,6 +1,8 @@
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 
+#define SPX_NAMESPACE(s) SPX_##s
+
 /* Hash output length in bytes. */
 #define SPX_N 16
 /* Height of the hypertree. */

--- a/ref/params/params-sphincs-haraka-128s.h
+++ b/ref/params/params-sphincs-haraka-128s.h
@@ -1,6 +1,8 @@
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 
+#define SPX_NAMESPACE(s) SPX_##s
+
 /* Hash output length in bytes. */
 #define SPX_N 16
 /* Height of the hypertree. */

--- a/ref/params/params-sphincs-haraka-192f.h
+++ b/ref/params/params-sphincs-haraka-192f.h
@@ -1,6 +1,8 @@
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 
+#define SPX_NAMESPACE(s) SPX_##s
+
 /* Hash output length in bytes. */
 #define SPX_N 24
 /* Height of the hypertree. */

--- a/ref/params/params-sphincs-haraka-192s.h
+++ b/ref/params/params-sphincs-haraka-192s.h
@@ -1,6 +1,8 @@
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 
+#define SPX_NAMESPACE(s) SPX_##s
+
 /* Hash output length in bytes. */
 #define SPX_N 24
 /* Height of the hypertree. */

--- a/ref/params/params-sphincs-haraka-256f.h
+++ b/ref/params/params-sphincs-haraka-256f.h
@@ -1,6 +1,8 @@
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 
+#define SPX_NAMESPACE(s) SPX_##s
+
 /* Hash output length in bytes. */
 #define SPX_N 32
 /* Height of the hypertree. */

--- a/ref/params/params-sphincs-haraka-256s.h
+++ b/ref/params/params-sphincs-haraka-256s.h
@@ -1,6 +1,8 @@
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 
+#define SPX_NAMESPACE(s) SPX_##s
+
 /* Hash output length in bytes. */
 #define SPX_N 32
 /* Height of the hypertree. */

--- a/ref/params/params-sphincs-sha2-128f.h
+++ b/ref/params/params-sphincs-sha2-128f.h
@@ -1,6 +1,8 @@
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 
+#define SPX_NAMESPACE(s) SPX_##s
+
 /* Hash output length in bytes. */
 #define SPX_N 16
 /* Height of the hypertree. */

--- a/ref/params/params-sphincs-sha2-128s.h
+++ b/ref/params/params-sphincs-sha2-128s.h
@@ -1,6 +1,8 @@
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 
+#define SPX_NAMESPACE(s) SPX_##s
+
 /* Hash output length in bytes. */
 #define SPX_N 16
 /* Height of the hypertree. */

--- a/ref/params/params-sphincs-sha2-192f.h
+++ b/ref/params/params-sphincs-sha2-192f.h
@@ -1,6 +1,8 @@
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 
+#define SPX_NAMESPACE(s) SPX_##s
+
 /* Hash output length in bytes. */
 #define SPX_N 24
 /* Height of the hypertree. */

--- a/ref/params/params-sphincs-sha2-192s.h
+++ b/ref/params/params-sphincs-sha2-192s.h
@@ -1,6 +1,8 @@
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 
+#define SPX_NAMESPACE(s) SPX_##s
+
 /* Hash output length in bytes. */
 #define SPX_N 24
 /* Height of the hypertree. */

--- a/ref/params/params-sphincs-sha2-256f.h
+++ b/ref/params/params-sphincs-sha2-256f.h
@@ -1,6 +1,8 @@
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 
+#define SPX_NAMESPACE(s) SPX_##s
+
 /* Hash output length in bytes. */
 #define SPX_N 32
 /* Height of the hypertree. */

--- a/ref/params/params-sphincs-sha2-256s.h
+++ b/ref/params/params-sphincs-sha2-256s.h
@@ -1,6 +1,8 @@
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 
+#define SPX_NAMESPACE(s) SPX_##s
+
 /* Hash output length in bytes. */
 #define SPX_N 32
 /* Height of the hypertree. */

--- a/ref/params/params-sphincs-shake-128f.h
+++ b/ref/params/params-sphincs-shake-128f.h
@@ -1,6 +1,8 @@
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 
+#define SPX_NAMESPACE(s) SPX_##s
+
 /* Hash output length in bytes. */
 #define SPX_N 16
 /* Height of the hypertree. */

--- a/ref/params/params-sphincs-shake-128s.h
+++ b/ref/params/params-sphincs-shake-128s.h
@@ -1,6 +1,8 @@
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 
+#define SPX_NAMESPACE(s) SPX_##s
+
 /* Hash output length in bytes. */
 #define SPX_N 16
 /* Height of the hypertree. */

--- a/ref/params/params-sphincs-shake-192f.h
+++ b/ref/params/params-sphincs-shake-192f.h
@@ -1,6 +1,8 @@
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 
+#define SPX_NAMESPACE(s) SPX_##s
+
 /* Hash output length in bytes. */
 #define SPX_N 24
 /* Height of the hypertree. */

--- a/ref/params/params-sphincs-shake-192s.h
+++ b/ref/params/params-sphincs-shake-192s.h
@@ -1,6 +1,8 @@
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 
+#define SPX_NAMESPACE(s) SPX_##s
+
 /* Hash output length in bytes. */
 #define SPX_N 24
 /* Height of the hypertree. */

--- a/ref/params/params-sphincs-shake-256f.h
+++ b/ref/params/params-sphincs-shake-256f.h
@@ -1,6 +1,8 @@
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 
+#define SPX_NAMESPACE(s) SPX_##s
+
 /* Hash output length in bytes. */
 #define SPX_N 32
 /* Height of the hypertree. */

--- a/ref/params/params-sphincs-shake-256s.h
+++ b/ref/params/params-sphincs-shake-256s.h
@@ -1,6 +1,8 @@
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 
+#define SPX_NAMESPACE(s) SPX_##s
+
 /* Hash output length in bytes. */
 #define SPX_N 32
 /* Height of the hypertree. */

--- a/ref/rng.c
+++ b/ref/rng.c
@@ -102,7 +102,7 @@ seedexpander(AES_XOF_struct *ctx, unsigned char *x, unsigned long xlen)
 }
 
 
-void handleErrors(void)
+static void handleErrors(void)
 {
     ERR_print_errors_fp(stderr);
     abort();

--- a/ref/sha2.c
+++ b/ref/sha2.c
@@ -286,7 +286,7 @@ static size_t crypto_hashblocks_sha256(uint8_t *statebytes,
     return inlen;
 }
 
-int crypto_hashblocks_sha512(unsigned char *statebytes,const unsigned char *in,unsigned long long inlen)
+static int crypto_hashblocks_sha512(unsigned char *statebytes,const unsigned char *in,unsigned long long inlen)
 {
   uint64_t state[8];
   uint64_t a;

--- a/ref/sha2.h
+++ b/ref/sha2.h
@@ -1,6 +1,8 @@
 #ifndef SPX_SHA2_H
 #define SPX_SHA2_H
 
+#include "params.h"
+
 #define SPX_SHA256_BLOCK_BYTES 64
 #define SPX_SHA256_OUTPUT_BYTES 32  /* This does not necessarily equal SPX_N */
 
@@ -26,12 +28,15 @@ void sha512_inc_blocks(uint8_t *state, const uint8_t *in, size_t inblocks);
 void sha512_inc_finalize(uint8_t *out, uint8_t *state, const uint8_t *in, size_t inlen);
 void sha512(uint8_t *out, const uint8_t *in, size_t inlen);
 
+#define mgf1_256 SPX_NAMESPACE(mgf1_256)
 void mgf1_256(unsigned char *out, unsigned long outlen,
           const unsigned char *in, unsigned long inlen);
 
+#define mgf1_512 SPX_NAMESPACE(mgf1_512)
 void mgf1_512(unsigned char *out, unsigned long outlen,
           const unsigned char *in, unsigned long inlen);
 
+#define seed_state SPX_NAMESPACE(seed_state)
 void seed_state(spx_ctx *ctx);
 
 

--- a/ref/thash.h
+++ b/ref/thash.h
@@ -2,9 +2,11 @@
 #define SPX_THASH_H
 
 #include "context.h"
+#include "params.h"
 
 #include <stdint.h>
 
+#define thash SPX_NAMESPACE(thash)
 void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
            const spx_ctx *ctx, uint32_t addr[8]);
 

--- a/ref/utils.h
+++ b/ref/utils.h
@@ -9,19 +9,23 @@
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
  */
+#define ull_to_bytes SPX_NAMESPACE(ull_to_bytes)
 void ull_to_bytes(unsigned char *out, unsigned int outlen,
                   unsigned long long in);
+#define u32_to_bytes SPX_NAMESPACE(u32_to_bytes)
 void u32_to_bytes(unsigned char *out, uint32_t in);
 
 /**
  * Converts the inlen bytes in 'in' from big-endian byte order to an integer.
  */
+#define bytes_to_ull SPX_NAMESPACE(bytes_to_ull)
 unsigned long long bytes_to_ull(const unsigned char *in, unsigned int inlen);
 
 /**
  * Computes a root node given a leaf and an auth path.
  * Expects address to be complete other than the tree_height and tree_index.
  */
+#define compute_root SPX_NAMESPACE(compute_root)
 void compute_root(unsigned char *root, const unsigned char *leaf,
                   uint32_t leaf_idx, uint32_t idx_offset,
                   const unsigned char *auth_path, uint32_t tree_height,
@@ -35,6 +39,7 @@ void compute_root(unsigned char *root, const unsigned char *leaf,
  * Applies the offset idx_offset to indices before building addresses, so that
  * it is possible to continue counting indices across trees.
  */
+#define treehash SPX_NAMESPACE(treehash)
 void treehash(unsigned char *root, unsigned char *auth_path,
               const spx_ctx* ctx,
               uint32_t leaf_idx, uint32_t idx_offset, uint32_t tree_height,

--- a/ref/utilsx1.h
+++ b/ref/utilsx1.h
@@ -13,6 +13,7 @@
  * Applies the offset idx_offset to indices before building addresses, so that
  * it is possible to continue counting indices across trees.
  */
+#define treehashx1 SPX_NAMESPACE(treehashx1)
 void treehashx1(unsigned char *root, unsigned char *auth_path,
                 const spx_ctx* ctx,
                 uint32_t leaf_idx, uint32_t idx_offset, uint32_t tree_height,

--- a/ref/wots.h
+++ b/ref/wots.h
@@ -11,6 +11,7 @@
  *
  * Writes the computed public key to 'pk'.
  */
+#define wots_pk_from_sig SPX_NAMESPACE(wots_pk_from_sig)
 void wots_pk_from_sig(unsigned char *pk,
                       const unsigned char *sig, const unsigned char *msg,
                       const spx_ctx *ctx, uint32_t addr[8]);
@@ -18,6 +19,7 @@ void wots_pk_from_sig(unsigned char *pk,
 /*
  * Compute the chain lengths needed for a given message hash
  */
+#define chain_lengths SPX_NAMESPACE(chain_lengths)
 void chain_lengths(unsigned int *lengths, const unsigned char *msg);
 
 #endif

--- a/ref/wotsx1.h
+++ b/ref/wotsx1.h
@@ -28,6 +28,7 @@ struct leaf_info_x1 {
     memcpy( &info.pk_addr[0], addr, 32 ); \
 }
 
+#define wots_gen_leafx1 SPX_NAMESPACE(wots_gen_leafx1)
 void wots_gen_leafx1(unsigned char *dest,
                    const spx_ctx *ctx,
                    uint32_t leaf_idx, void *v_info);

--- a/sha2-avx2/Makefile
+++ b/sha2-avx2/Makefile
@@ -2,7 +2,7 @@ PARAMS = sphincs-sha2-128f
 THASH = robust
 
 CC = /usr/bin/gcc
-CFLAGS = -Wall -Wextra -Wpedantic -O3 -std=c99 -march=native -fomit-frame-pointer -flto -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
+CFLAGS = -Wall -Wextra -Wpedantic -Wmissing-prototypes -O3 -std=c99 -march=native -flto -fomit-frame-pointer -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
 
 
 SOURCES =          hash_sha2.c hash_sha2x8.c thash_sha2_$(THASH).c thash_sha2_$(THASH)x8.c sha2.c sha256x8.c sha512x4.c sha256avx.c address.c randombytes.c merkle.c wots.c utils.c utilsx8.c fors.c sign.c

--- a/sha2-avx2/hashx8.h
+++ b/sha2-avx2/hashx8.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include "params.h"
 
+#define prf_addrx8 SPX_NAMESPACE(prf_addrx8)
 void prf_addrx8(unsigned char *out0,
                 unsigned char *out1,
                 unsigned char *out2,

--- a/sha2-avx2/sha256x8.h
+++ b/sha2-avx2/sha256x8.h
@@ -1,6 +1,8 @@
 #ifndef SPX_SHA256X8_H
 #define SPX_SHA256X8_H
 
+#include "params.h"
+
 #define SPX_SHA256_BLOCK_BYTES 64
 #define SPX_SHA256_OUTPUT_BYTES 32  /* This does not necessarily equal SPX_N */
 
@@ -8,6 +10,7 @@
     #error Linking against SHA-256 with N larger than 32 bytes is not supported
 #endif
 
+#define sha256x8_seeded SPX_NAMESPACE(sha256x8_seeded)
 void sha256x8_seeded(
               unsigned char *out0,
               unsigned char *out1,
@@ -29,6 +32,7 @@ void sha256x8_seeded(
               const unsigned char *in7, unsigned long long inlen);
 
 /* This provides a wrapper around the internals of 8x parallel SHA256 */
+#define sha256x8 SPX_NAMESPACE(sha256x8)
 void sha256x8(unsigned char *out0,
               unsigned char *out1,
               unsigned char *out2,
@@ -51,6 +55,7 @@ void sha256x8(unsigned char *out0,
  * an array to be allocated on the stack. Typically 'in' is merely a seed.
  * Outputs outlen number of bytes
  */
+#define mgf1x8 SPX_NAMESPACE(mgf1x8)
 void mgf1x8(unsigned char *outx8, unsigned long outlen,
             const unsigned char *in0,
             const unsigned char *in1,

--- a/sha2-avx2/sha512x4.c
+++ b/sha2-avx2/sha512x4.c
@@ -51,7 +51,7 @@ static void transpose(u256 s[4]) {
 }
 
 
-void sha512_init4x(sha512ctx4x *ctx) {
+static void sha512_init4x(sha512ctx4x *ctx) {
 #define SET4(x) _mm256_set_epi64x(x, x, x, x)
     ctx->s[0] = SET4(0x6a09e667f3bcc908ULL);
     ctx->s[1] = SET4(0xbb67ae8584caa73bULL);

--- a/sha2-avx2/sha512x4.h
+++ b/sha2-avx2/sha512x4.h
@@ -3,6 +3,8 @@
 #include <stdint.h>
 #include "immintrin.h"
 
+#include "params.h"
+
 typedef struct SHA512state4x {
     __m256i s[8];
     unsigned char msgblocks[4*128];
@@ -11,6 +13,7 @@ typedef struct SHA512state4x {
 } sha512ctx4x;
 
 
+#define sha512x4_seeded SPX_NAMESPACE(sha512x4_seeded)
 void sha512x4_seeded(
     unsigned char *out0,
     unsigned char *out1,
@@ -30,6 +33,7 @@ void sha512x4_seeded(
  * an array to be allocated on the stack. Typically 'in' is merely a seed.
  * Outputs outlen number of bytes
  */
+#define mgf1x4_512 SPX_NAMESPACE(mgf1x4_512)
 void mgf1x4_512(unsigned char *outx4, unsigned long outlen,
             const unsigned char *in0,
             const unsigned char *in1,

--- a/sha2-avx2/thashx8.h
+++ b/sha2-avx2/thashx8.h
@@ -3,7 +3,9 @@
 
 #include <stdint.h>
 #include "context.h"
+#include "params.h"
 
+#define thashx8 SPX_NAMESPACE(thashx8)
 void thashx8(unsigned char *out0,
              unsigned char *out1,
              unsigned char *out2,

--- a/sha2-avx2/utilsx8.c
+++ b/sha2-avx2/utilsx8.c
@@ -1,6 +1,7 @@
 #include <string.h>
 
 #include "utils.h"
+#include "utilsx8.h"
 #include "params.h"
 #include "thashx8.h"
 #include "address.h"

--- a/sha2-avx2/utilsx8.h
+++ b/sha2-avx2/utilsx8.h
@@ -15,6 +15,7 @@
  * This implementation uses AVX to compute internal nodes 8 at a time (in
  * parallel)
  */
+#define treehashx8 SPX_NAMESPACE(treehashx8)
 void treehashx8(unsigned char *root, unsigned char *auth_path,
                 const spx_ctx *ctx,
                 uint32_t leaf_idx, uint32_t idx_offset, uint32_t tree_height,

--- a/sha2-avx2/wotsx8.h
+++ b/sha2-avx2/wotsx8.h
@@ -2,6 +2,7 @@
 #define WOTSX8_H_ 
 
 #include <string.h>
+#include "params.h"
 
 /*
  * This is here to provide an interface to the internal wots_gen_leafx8
@@ -31,6 +32,7 @@ struct leaf_info_x8 {
     } \
 }
 
+#define wots_gen_leafx8 SPX_NAMESPACE(wots_gen_leafx8)
 void wots_gen_leafx8(unsigned char *dest,
                    const spx_ctx *ctx,
                    uint32_t leaf_idx, void *v_info);

--- a/shake-a64/Makefile
+++ b/shake-a64/Makefile
@@ -1,7 +1,7 @@
 PARAMS = sphincs-shake-128f
 THASH = robust
 
-CFLAGS = -Wall -Wextra -Wpedantic -O3 -std=c99 -fomit-frame-pointer -flto -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
+CFLAGS = -Wall -Wextra -Wpedantic -Wmissing-prototypes -O3 -std=c99 -fomit-frame-pointer -flto -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
 
 SOURCES =          hash_shake.c hash_shakex2.c thash_shake_$(THASH)x2.c address.c randombytes.c merkle.c wots.c utils.c utilsx2.c fors.c sign.c fips202.c fips202x2.c f1600x2.c f1600x2.s
 HEADERS = params.h hash.h          hashx2.h                          thashx2.h                 address.h randombytes.h merkle.h wots.h utils.h utilsx2.h fors.h api.h fips202.h fips202x2.h f1600x2.h thash.h

--- a/shake-a64/hashx2.h
+++ b/shake-a64/hashx2.h
@@ -3,7 +3,9 @@
 
 #include <stdint.h>
 #include "context.h"
+#include "params.h"
 
+#define prf_addrx2 SPX_NAMESPACE(prf_addrx2)
 void prf_addrx2(unsigned char *out0,
                 unsigned char *out1,
                 const spx_ctx *ctx,

--- a/shake-a64/thashx2.h
+++ b/shake-a64/thashx2.h
@@ -3,7 +3,9 @@
 
 #include <stdint.h>
 #include "context.h"
+#include "params.h"
 
+#define thashx2 SPX_NAMESPACE(thashx2)
 void thashx2(unsigned char *out0,
              unsigned char *out1,
              const unsigned char *in0,

--- a/shake-a64/utilsx2.c
+++ b/shake-a64/utilsx2.c
@@ -1,6 +1,7 @@
 #include <string.h>
 
 #include "utils.h"
+#include "utilsx2.h"
 #include "params.h"
 #include "thashx2.h"
 #include "address.h"

--- a/shake-a64/utilsx2.h
+++ b/shake-a64/utilsx2.h
@@ -15,6 +15,7 @@
  * This implementation uses SIMD to compute internal nodes 2 at a time (in
  * parallel)
  */
+#define treehashx2 SPX_NAMESPACE(treehashx2)
 void treehashx2(unsigned char *root, unsigned char *auth_path,
                 const spx_ctx *ctx,
                 uint32_t leaf_idx, uint32_t idx_offset, uint32_t tree_height,

--- a/shake-a64/wotsx2.h
+++ b/shake-a64/wotsx2.h
@@ -2,6 +2,7 @@
 #define WOTSX2_H_ 
 
 #include <string.h>
+#include "params.h"
 
 /*
  * This is here to provide an interface to the internal wots_gen_leafx2
@@ -31,6 +32,7 @@ struct leaf_info_x2 {
     } \
 }
 
+#define wots_gen_leafx2 SPX_NAMESPACE(wots_gen_leafx2)
 void wots_gen_leafx2(unsigned char *dest,
                    const spx_ctx *ctx,
                    uint32_t leaf_idx, void *v_info);

--- a/shake-avx2/Makefile
+++ b/shake-avx2/Makefile
@@ -2,7 +2,7 @@ PARAMS = sphincs-shake-128f
 THASH = robust
 
 CC = /usr/bin/gcc
-CFLAGS = -Wall -Wextra -Wpedantic -O3 -std=c99 -march=native -fomit-frame-pointer -flto -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
+CFLAGS = -Wall -Wextra -Wpedantic -Wmissing-prototypes -O3 -std=c99 -march=native -fomit-frame-pointer -flto -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
 
 SOURCES =          hash_shake.c hash_shakex4.c thash_shake_$(THASH).c thash_shake_$(THASH)x4.c address.c randombytes.c merkle.c wots.c utils.c utilsx4.c fors.c sign.c fips202.c fips202x4.c keccak4x/KeccakP-1600-times4-SIMD256.o
 HEADERS = params.h hash.h          hashx4.h          thash.h                 thashx4.h                 address.h randombytes.h merkle.h wots.h utils.h utilsx4.h fors.h api.h fips202.h fips202x4.h

--- a/shake-avx2/fips202x4.c
+++ b/shake-avx2/fips202x4.c
@@ -1,7 +1,9 @@
 #include <immintrin.h>
 #include <stdint.h>
 #include <assert.h>
+
 #include "fips202.h"
+#include "fips202x4.h"
 
 #define NROUNDS 24
 #define ROL(a, offset) ((a << offset) ^ (a >> (64-offset)))

--- a/shake-avx2/hashx4.h
+++ b/shake-avx2/hashx4.h
@@ -3,7 +3,9 @@
 
 #include <stdint.h>
 #include "context.h"
+#include "params.h"
 
+#define prf_addrx4 SPX_NAMESPACE(prf_addrx4)
 void prf_addrx4(unsigned char *out0,
                 unsigned char *out1,
                 unsigned char *out2,

--- a/shake-avx2/thashx4.h
+++ b/shake-avx2/thashx4.h
@@ -3,7 +3,9 @@
 
 #include <stdint.h>
 #include "context.h"
+#include "params.h"
 
+#define thashx4 SPX_NAMESPACE(thashx4)
 void thashx4(unsigned char *out0,
              unsigned char *out1,
              unsigned char *out2,

--- a/shake-avx2/utilsx4.c
+++ b/shake-avx2/utilsx4.c
@@ -1,6 +1,7 @@
 #include <string.h>
 
 #include "utils.h"
+#include "utilsx4.h"
 #include "params.h"
 #include "thashx4.h"
 #include "address.h"

--- a/shake-avx2/utilsx4.h
+++ b/shake-avx2/utilsx4.h
@@ -15,6 +15,7 @@
  * This implementation uses AVX to compute internal nodes 4 at a time (in
  * parallel)
  */
+#define treehashx4 SPX_NAMESPACE(treehashx4)
 void treehashx4(unsigned char *root, unsigned char *auth_path,
                 const spx_ctx *ctx,
                 uint32_t leaf_idx, uint32_t idx_offset, uint32_t tree_height,

--- a/shake-avx2/wotsx4.h
+++ b/shake-avx2/wotsx4.h
@@ -1,7 +1,8 @@
 #if !defined( WOTSX4_H_ )
-#define WOTSX4_H_ 
+#define WOTSX4_H_
 
 #include <string.h>
+#include "params.h"
 
 /*
  * This is here to provide an interface to the internal wots_gen_leafx4
@@ -31,6 +32,7 @@ struct leaf_info_x4 {
     } \
 }
 
+#define wots_gen_leafx4 SPX_NAMESPACE(wots_gen_leafx4)
 void wots_gen_leafx4(unsigned char *dest,
                    const spx_ctx *ctx,
                    uint32_t leaf_idx, void *v_info);

--- a/vectors.py
+++ b/vectors.py
@@ -90,7 +90,7 @@ def check_sum(name, impl):
             sys.stderr.write(f"Test vector mismatch: {line}\n")
             sys.exit(2)
         sys.stderr.write("ok\n")
-        
+
 if __name__ == '__main__':
     if len(sys.argv) <= 1:
         generate_sums()


### PR DESCRIPTION
This PR adds a namespacing macro to the `params/*.h` files and wraps all function definitions in header files in the macro. This will ease downstreaming into projects like PQClean or liboqs.

The following are still open discussion items:

* The namespace is currently just `SPX_` for all schemes. It would probably be more useful if it's `SPX_THASH_SIZE_VARIANT_X_`, otherwise different versions of SPHINCS+ will still collide. 
* I've not namespaced `api.h` yet, because that affects the NIST api. For actual use, these function will need to be namespaced. We could possibly work around this by offering `nistapi.h` as an alternative if we do choose to namespace `api.h` (or just patch the KAT script).
* I've not namespaced the hash primitives, neither the "plain" ones (that would be replaced by PQClean's or OQS's hashing providers) or the parallel hashing ones (shakex8) for which PQClean doesn't have a `common` provider.

To make my life easier, this PR builds on #36 
