### PR TITLE
Enable -Wconversion in `ref`

### DIFF
--- a/ref/Makefile
+++ b/ref/Makefile
@@ -2,7 +2,7 @@ PARAMS = sphincs-haraka-128f
 THASH = robust
 
 CC=/usr/bin/gcc
-CFLAGS=-Wall -Wextra -Wpedantic -O3 -std=c99 -Wmissing-prototypes -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
+CFLAGS=-Wall -Wextra -Wpedantic -O3 -std=c99 -Wconversion -Wmissing-prototypes -DPARAMS=$(PARAMS) $(EXTRA_CFLAGS)
 
 SOURCES =          address.c randombytes.c merkle.c wots.c wotsx1.c utils.c utilsx1.c fors.c sign.c
 HEADERS = params.h address.h randombytes.h merkle.h wots.h wotsx1.h utils.h utilsx1.h fors.h api.h  hash.h thash.h

--- a/ref/address.c
+++ b/ref/address.c
@@ -10,7 +10,7 @@
  */
 void set_layer_addr(uint32_t addr[8], uint32_t layer)
 {
-    ((unsigned char *)addr)[SPX_OFFSET_LAYER] = layer;
+    ((unsigned char *)addr)[SPX_OFFSET_LAYER] = (unsigned char)layer;
 }
 
 /*
@@ -32,7 +32,7 @@ void set_tree_addr(uint32_t addr[8], uint64_t tree)
  */
 void set_type(uint32_t addr[8], uint32_t type)
 {
-    ((unsigned char *)addr)[SPX_OFFSET_TYPE] = type;
+    ((unsigned char *)addr)[SPX_OFFSET_TYPE] = (unsigned char)type;
 }
 
 /*
@@ -55,9 +55,9 @@ void set_keypair_addr(uint32_t addr[8], uint32_t keypair)
 #if SPX_FULL_HEIGHT/SPX_D > 8
         /* We have > 256 OTS at the bottom of the Merkle tree; to specify */
         /* which one, we'd need to express it in two bytes */
-    ((unsigned char *)addr)[SPX_OFFSET_KP_ADDR2] = keypair >> 8;
+    ((unsigned char *)addr)[SPX_OFFSET_KP_ADDR2] = (unsigned char)(keypair >> 8);
 #endif
-    ((unsigned char *)addr)[SPX_OFFSET_KP_ADDR1] = keypair;
+    ((unsigned char *)addr)[SPX_OFFSET_KP_ADDR1] = (unsigned char)keypair;
 }
 
 /*
@@ -79,7 +79,7 @@ void copy_keypair_addr(uint32_t out[8], const uint32_t in[8])
  */
 void set_chain_addr(uint32_t addr[8], uint32_t chain)
 {
-    ((unsigned char *)addr)[SPX_OFFSET_CHAIN_ADDR] = chain;
+    ((unsigned char *)addr)[SPX_OFFSET_CHAIN_ADDR] = (unsigned char)chain;
 }
 
 /*
@@ -88,7 +88,7 @@ void set_chain_addr(uint32_t addr[8], uint32_t chain)
  */
 void set_hash_addr(uint32_t addr[8], uint32_t hash)
 {
-    ((unsigned char *)addr)[SPX_OFFSET_HASH_ADDR] = hash;
+    ((unsigned char *)addr)[SPX_OFFSET_HASH_ADDR] = (unsigned char)hash;
 }
 
 /* These functions are used for all hash tree addresses (including FORS). */
@@ -99,7 +99,7 @@ void set_hash_addr(uint32_t addr[8], uint32_t hash)
  */
 void set_tree_height(uint32_t addr[8], uint32_t tree_height)
 {
-    ((unsigned char *)addr)[SPX_OFFSET_TREE_HGT] = tree_height;
+    ((unsigned char *)addr)[SPX_OFFSET_TREE_HGT] = (unsigned char)tree_height;
 }
 
 /*

--- a/ref/haraka.c
+++ b/ref/haraka.c
@@ -1,8 +1,8 @@
 /*
  * Constant time implementation of the Haraka hash function.
- * 
+ *
  * The bit-sliced implementation of the AES round functions are
- * based on the AES implementation in BearSSL written 
+ * based on the AES implementation in BearSSL written
  * by Thomas Pornin <pornin@bolet.org>
  */
 
@@ -29,7 +29,7 @@ static const uint64_t haraka512_rc64[10][8] = {
     {0x83497348628d84de, 0x2e9387d51f22a754, 0xb000068da2f852d6, 0x378c9e1190fd6fe5, 0x870027c316de7293, 0xe51a9d4462e047bb, 0x90ecf7f8c6251195, 0x655953bfbed90a9c},
 };
 
-static inline uint32_t br_dec32le(const unsigned char *src) 
+static inline uint32_t br_dec32le(const unsigned char *src)
 {
     return (uint32_t)src[0]
            | ((uint32_t)src[1] << 8)
@@ -37,7 +37,7 @@ static inline uint32_t br_dec32le(const unsigned char *src)
            | ((uint32_t)src[3] << 24);
 }
 
-static void br_range_dec32le(uint32_t *v, size_t num, const unsigned char *src) 
+static void br_range_dec32le(uint32_t *v, size_t num, const unsigned char *src)
 {
     while (num-- > 0) {
         *v ++ = br_dec32le(src);
@@ -45,7 +45,7 @@ static void br_range_dec32le(uint32_t *v, size_t num, const unsigned char *src)
     }
 }
 
-static inline void br_enc32le(unsigned char *dst, uint32_t x) 
+static inline void br_enc32le(unsigned char *dst, uint32_t x)
 {
     dst[0] = (unsigned char)x;
     dst[1] = (unsigned char)(x >> 8);
@@ -54,7 +54,7 @@ static inline void br_enc32le(unsigned char *dst, uint32_t x)
 }
 
 
-static void br_range_enc32le(unsigned char *dst, const uint32_t *v, size_t num) 
+static void br_range_enc32le(unsigned char *dst, const uint32_t *v, size_t num)
 {
     while (num-- > 0) {
         br_enc32le(dst, *v ++);
@@ -441,7 +441,7 @@ static void br_aes_ct_ortho(uint32_t *q)
     SWAP8_32(q[3], q[7]);
 }
 
-static inline void add_round_key32(uint32_t *q, const uint32_t *sk) 
+static inline void add_round_key32(uint32_t *q, const uint32_t *sk)
 {
     q[0] ^= sk[0];
     q[1] ^= sk[1];
@@ -505,7 +505,7 @@ static inline void mix_columns32(uint32_t *q)
     q[7] = q6 ^ r6 ^ r7 ^ rotr16(q7 ^ r7);
 }
 
-static void br_aes_ct64_ortho(uint64_t *q) 
+static void br_aes_ct64_ortho(uint64_t *q)
 {
 #define SWAPN(cl, ch, s, x, y)   do { \
         uint64_t a, b; \
@@ -536,7 +536,7 @@ static void br_aes_ct64_ortho(uint64_t *q)
 }
 
 
-static void br_aes_ct64_interleave_in(uint64_t *q0, uint64_t *q1, const uint32_t *w) 
+static void br_aes_ct64_interleave_in(uint64_t *q0, uint64_t *q1, const uint32_t *w)
 {
     uint64_t x0, x1, x2, x3;
 
@@ -565,7 +565,7 @@ static void br_aes_ct64_interleave_in(uint64_t *q0, uint64_t *q1, const uint32_t
 }
 
 
-static void br_aes_ct64_interleave_out(uint32_t *w, uint64_t q0, uint64_t q1) 
+static void br_aes_ct64_interleave_out(uint32_t *w, uint64_t q0, uint64_t q1)
 {
     uint64_t x0, x1, x2, x3;
 
@@ -587,7 +587,7 @@ static void br_aes_ct64_interleave_out(uint32_t *w, uint64_t q0, uint64_t q1)
     w[3] = (uint32_t)x3 | (uint32_t)(x3 >> 16);
 }
 
-static inline void add_round_key(uint64_t *q, const uint64_t *sk) 
+static inline void add_round_key(uint64_t *q, const uint64_t *sk)
 {
     q[0] ^= sk[0];
     q[1] ^= sk[1];
@@ -599,7 +599,7 @@ static inline void add_round_key(uint64_t *q, const uint64_t *sk)
     q[7] ^= sk[7];
 }
 
-static inline void shift_rows(uint64_t *q) 
+static inline void shift_rows(uint64_t *q)
 {
     int i;
 
@@ -617,12 +617,12 @@ static inline void shift_rows(uint64_t *q)
     }
 }
 
-static inline uint64_t rotr32(uint64_t x) 
+static inline uint64_t rotr32(uint64_t x)
 {
     return (x << 32) | (x >> 32);
 }
 
-static inline void mix_columns(uint64_t *q) 
+static inline void mix_columns(uint64_t *q)
 {
     uint64_t q0, q1, q2, q3, q4, q5, q6, q7;
     uint64_t r0, r1, r2, r3, r4, r5, r6, r7;
@@ -757,7 +757,7 @@ void haraka_S_inc_absorb(uint8_t *s_inc, const uint8_t *m, size_t mlen,
             s_inc[s_inc[64] + i] ^= m[i];
         }
         mlen -= (size_t)(HARAKAS_RATE - s_inc[64]);
-        m += HARAKAS_RATE - s_inc[64];
+        m += HARAKAS_RATE - (uint8_t)s_inc[64];
         s_inc[64] = 0;
 
         haraka512_perm(s_inc, s_inc, ctx);
@@ -766,7 +766,7 @@ void haraka_S_inc_absorb(uint8_t *s_inc, const uint8_t *m, size_t mlen,
     for (i = 0; i < mlen; i++) {
         s_inc[s_inc[64] + i] ^= m[i];
     }
-    s_inc[64] += mlen;
+    s_inc[64] += (uint8_t)mlen;
 }
 
 void haraka_S_inc_finalize(uint8_t *s_inc)
@@ -791,7 +791,7 @@ void haraka_S_inc_squeeze(uint8_t *out, size_t outlen, uint8_t *s_inc,
     }
     out += i;
     outlen -= i;
-    s_inc[64] -= i;
+    s_inc[64] -= (uint8_t)i;
 
     /* Then squeeze the remaining necessary blocks */
     while (outlen > 0) {
@@ -802,7 +802,7 @@ void haraka_S_inc_squeeze(uint8_t *out, size_t outlen, uint8_t *s_inc,
         }
         out += i;
         outlen -= i;
-        s_inc[64] = HARAKAS_RATE - i;
+        s_inc[64] = (uint8_t)(HARAKAS_RATE - i);
     }
 }
 
@@ -855,17 +855,17 @@ void haraka512_perm(unsigned char *out, const unsigned char *in,
         for (j = 0; j < 8; j++) {
             tmp_q = q[j];
             q[j] = (tmp_q & 0x0001000100010001) << 5 |
-                   (tmp_q & 0x0002000200020002) << 12 | 
-                   (tmp_q & 0x0004000400040004) >> 1 | 
-                   (tmp_q & 0x0008000800080008) << 6 | 
-                   (tmp_q & 0x0020002000200020) << 9 | 
-                   (tmp_q & 0x0040004000400040) >> 4 | 
-                   (tmp_q & 0x0080008000800080) << 3 | 
+                   (tmp_q & 0x0002000200020002) << 12 |
+                   (tmp_q & 0x0004000400040004) >> 1 |
+                   (tmp_q & 0x0008000800080008) << 6 |
+                   (tmp_q & 0x0020002000200020) << 9 |
+                   (tmp_q & 0x0040004000400040) >> 4 |
+                   (tmp_q & 0x0080008000800080) << 3 |
                    (tmp_q & 0x2100210021002100) >> 5 |
-                   (tmp_q & 0x0210021002100210) << 2 | 
-                   (tmp_q & 0x0800080008000800) << 4 | 
-                   (tmp_q & 0x1000100010001000) >> 12 | 
-                   (tmp_q & 0x4000400040004000) >> 10 | 
+                   (tmp_q & 0x0210021002100210) << 2 |
+                   (tmp_q & 0x0800080008000800) << 4 |
+                   (tmp_q & 0x1000100010001000) >> 12 |
+                   (tmp_q & 0x4000400040004000) >> 10 |
                    (tmp_q & 0x8400840084008400) >> 3;
         }
     }

--- a/ref/hash_haraka.c
+++ b/ref/hash_haraka.c
@@ -87,6 +87,6 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);
     bufp += SPX_TREE_BYTES;
 
-    *leaf_idx = bytes_to_ull(bufp, SPX_LEAF_BYTES);
+    *leaf_idx = (uint32_t)bytes_to_ull(bufp, SPX_LEAF_BYTES);
     *leaf_idx &= (~(uint32_t)0) >> (32 - SPX_LEAF_BITS);
 }

--- a/ref/hash_sha2.c
+++ b/ref/hash_sha2.c
@@ -186,7 +186,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);
     bufp += SPX_TREE_BYTES;
 
-    *leaf_idx = bytes_to_ull(bufp, SPX_LEAF_BYTES);
+    *leaf_idx = (uint32_t)bytes_to_ull(bufp, SPX_LEAF_BYTES);
     *leaf_idx &= (~(uint32_t)0) >> (32 - SPX_LEAF_BITS);
 }
 

--- a/ref/hash_shake.c
+++ b/ref/hash_shake.c
@@ -88,6 +88,6 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);
     bufp += SPX_TREE_BYTES;
 
-    *leaf_idx = bytes_to_ull(bufp, SPX_LEAF_BYTES);
+    *leaf_idx = (uint32_t)bytes_to_ull(bufp, SPX_LEAF_BYTES);
     *leaf_idx &= (~(uint32_t)0) >> (32 - SPX_LEAF_BITS);
 }

--- a/ref/merkle.c
+++ b/ref/merkle.c
@@ -14,7 +14,7 @@
  * authentication path).  This is in this file because most of the complexity
  * is involved with the WOTS signature; the Merkle authentication path logic
  * is mostly hidden in treehashx4
- */ 
+ */
 void merkle_sign(uint8_t *sig, unsigned char *root,
                  const spx_ctx *ctx,
                  uint32_t wots_addr[8], uint32_t tree_addr[8],
@@ -57,5 +57,5 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx)
 
     merkle_sign(auth_path, root, ctx,
                 wots_addr, top_tree_addr,
-                ~0 /* ~0 means "don't bother generating an auth path */ );
+                (uint32_t)~0 /* ~0 means "don't bother generating an auth path */ );
 }

--- a/ref/sha2_offsets.h
+++ b/ref/sha2_offsets.h
@@ -1,4 +1,4 @@
-#if !defined( SHA2_OFFSETS_H_ )
+#ifndef SHA2_OFFSETS_H_
 #define SHA2_OFFSETS_H_
 
 /*

--- a/ref/sign.c
+++ b/ref/sign.c
@@ -103,7 +103,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     unsigned char optrand[SPX_N];
     unsigned char mhash[SPX_FORS_MSG_BYTES];
     unsigned char root[SPX_N];
-    unsigned long long i;
+    uint32_t i;
     uint64_t tree;
     uint32_t idx_leaf;
     uint32_t wots_addr[8] = {0};
@@ -179,7 +179,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
     if (siglen != SPX_BYTES) {
         return -1;
     }
-    
+
     memcpy(ctx.pub_seed, pk, SPX_N);
 
     /* This hook allows the hash function instantiation to do whatever

--- a/ref/utils.c
+++ b/ref/utils.c
@@ -15,7 +15,7 @@ void ull_to_bytes(unsigned char *out, unsigned int outlen,
     int i;
 
     /* Iterate over out in decreasing order, for big-endianness. */
-    for (i = outlen - 1; i >= 0; i--) {
+    for (i = (signed int)outlen - 1; i >= 0; i--) {
         out[i] = in & 0xff;
         in = in >> 8;
     }

--- a/ref/utilsx1.c
+++ b/ref/utilsx1.c
@@ -12,7 +12,7 @@
  * Expects the layer and tree parts of the tree_addr to be set, as well as the
  * tree type (i.e. SPX_ADDR_TYPE_HASHTREE or SPX_ADDR_TYPE_FORSTREE)
  *
- * This expecta tree_addr to be initialized to the addr structures for the 
+ * This expects tree_addr to be initialized to the addr structures for the
  * Merkle tree nodes
  *
  * Applies the offset idx_offset to indices before building addresses, so that
@@ -35,7 +35,7 @@ void treehashx1(unsigned char *root, unsigned char *auth_path,
     SPX_VLA(uint8_t, stack, tree_height*SPX_N);
 
     uint32_t idx;
-    uint32_t max_idx = (1 << tree_height) - 1;
+    uint32_t max_idx = (uint32_t)((1 << tree_height) - 1);
     for (idx = 0;; idx++) {
         unsigned char current[2*SPX_N];   /* Current logical node is at */
             /* index[SPX_N].  We do this to minimize the number of copies */
@@ -57,7 +57,7 @@ void treehashx1(unsigned char *root, unsigned char *auth_path,
                 memcpy( root, &current[SPX_N], SPX_N );
                 return;
             }
-            
+
             /*
              * Check if the node we have is a part of the
              * authentication path; if it is, write it out

--- a/ref/wotsx1.c
+++ b/ref/wotsx1.c
@@ -31,7 +31,7 @@ void wots_gen_leafx1(unsigned char *dest,
         wots_k_mask = 0;
     } else {
         /* Nope, we're just generating pk's; turn off the signature logic */
-        wots_k_mask = ~0;
+        wots_k_mask = (uint32_t)~0;
     }
 
     set_keypair_addr( leaf_addr, leaf_idx );
@@ -45,7 +45,7 @@ void wots_gen_leafx1(unsigned char *dest,
         set_chain_addr(leaf_addr, i);
         set_hash_addr(leaf_addr, 0);
         set_type(leaf_addr, SPX_ADDR_TYPE_WOTSPRF);
- 
+
         prf_addr(buffer, ctx, leaf_addr);
 
         set_type(leaf_addr, SPX_ADDR_TYPE_WOTS);

--- a/shake-avx2/wots.c
+++ b/shake-avx2/wots.c
@@ -203,8 +203,8 @@ void wots_gen_leafx4(unsigned char *dest,
                                   /* 4 slots do the signatures come from */
     } else {
         /* Nope, we're just generating pk's; turn off the signature logic */
-        wots_k_mask = ~0;
-	wots_sign_index = 0;
+        wots_k_mask = (uint32_t)~0;
+	    wots_sign_index = 0;
     }
 
     for (j = 0; j < 4; j++) {


### PR DESCRIPTION
This PR enables `-Wconversion`. This warning makes you do lots of casts more explicitly than strictly necessary; e.g. truncation is defined in the standard. However, Microsoft compilers are a lot more picky about this, so this prepares for that.

Going through these files also produced a bunch of trailing-whitespace-eating; sorry for that noise but I thought it was better to just include it.

I haven't had time to touch the accelerated implementations yet; I'm currently still fighting with the other things necessary to integrate `ref` into PQClean.