### PR TITLE
ref/Makefile: add .so target and build with shake

### DIFF
--- a/ref/Makefile
+++ b/ref/Makefile
@@ -1,4 +1,4 @@
-PARAMS = sphincs-haraka-128f
+PARAMS = sphincs-shake-256f
 THASH = robust
 
 CC=/usr/bin/gcc
@@ -32,7 +32,7 @@ BENCHMARK = test/benchmark
 
 default: PQCgenKAT_sign
 
-all: PQCgenKAT_sign tests benchmarks
+all: PQCgenKAT_sign tests benchmarks libsphincs
 
 tests: $(TESTS)
 
@@ -63,3 +63,7 @@ clean:
 	-$(RM) PQCgenKAT_sign
 	-$(RM) PQCsignKAT_*.rsp
 	-$(RM) PQCsignKAT_*.req
+	-$(RM) libsphincs
+
+libsphincs:
+	$(CC) -shared -o libsphincs.so $(CFLAGS) $(SOURCES)

--- a/ref/Makefile
+++ b/ref/Makefile
@@ -32,7 +32,7 @@ BENCHMARK = test/benchmark
 
 default: PQCgenKAT_sign
 
-all: PQCgenKAT_sign tests benchmarks libsphincs
+all: PQCgenKAT_sign tests benchmarks libsphincsplus.so
 
 tests: $(TESTS)
 
@@ -63,14 +63,16 @@ clean:
 	-$(RM) PQCgenKAT_sign
 	-$(RM) PQCsignKAT_*.rsp
 	-$(RM) PQCsignKAT_*.req
-	-$(RM) libsphincs
+	-$(RM) libsphincsplus.so
 
-libsphincs:
-	$(CC) -shared -o libsphincs.so $(CFLAGS) $(SOURCES)
+libsphincsplus.so:
+	$(CC) -shared -o libsphincsplus.so $(CFLAGS) $(SOURCES)
 
-install:
-	mkdir -p /opt/sphincsplus/lib
-	mkdir -p /opt/sphincsplus/include
-	cp *.h /opt/sphincsplus/include
-	cp -a params /opt/sphincsplus/include
-	cp *.so /opt/sphincsplus/lib
+DESTDIR ?= /usr/local
+install: libsphincsplus.so
+		install -d $(DESTDIR)/include/sphincsplus/
+		install -d $(DESTDIR)/include/sphincsplus/params
+		install -d $(DESTDIR)/lib/
+		install -v *.h $(DESTDIR)/include/sphincsplus/
+		install -v params/* $(DESTDIR)/include/sphincsplus/params
+		install -v libsphincsplus.so $(DESTDIR)/lib/

--- a/ref/Makefile
+++ b/ref/Makefile
@@ -67,3 +67,10 @@ clean:
 
 libsphincs:
 	$(CC) -shared -o libsphincs.so $(CFLAGS) $(SOURCES)
+
+install:
+	mkdir -p /opt/sphincsplus/lib
+	mkdir -p /opt/sphincsplus/include
+	cp *.h /opt/sphincsplus/include
+	cp -a params /opt/sphincsplus/include
+	cp *.so /opt/sphincsplus/lib


### PR DESCRIPTION
I have no idea if you guys want this change... but I will say that unless your makefile builds a usable .so file then anyone wanting to use this code will likely fork your repo and fix the makefile as I did.

To be clear, we intend to use Sphincs+ for the Katzenpost decryption mix network for signing mix descriptors and for signing PKI consensus documents... it'll essentially be at the root of the security dependency graph. But Katzenpost is written in Golang! Yes it is, so I wrote these cgo bindings this morning: https://github.com/katzenpost/sphincsplus_cgo
