### PR TITLE
Fixes to support broader set of parameters

### DIFF
--- a/ref/address.c
+++ b/ref/address.c
@@ -52,12 +52,7 @@ void copy_subtree_addr(uint32_t out[8], const uint32_t in[8])
  */
 void set_keypair_addr(uint32_t addr[8], uint32_t keypair)
 {
-#if SPX_FULL_HEIGHT/SPX_D > 8
-        /* We have > 256 OTS at the bottom of the Merkle tree; to specify */
-        /* which one, we'd need to express it in two bytes */
-    ((unsigned char *)addr)[SPX_OFFSET_KP_ADDR2] = (unsigned char)(keypair >> 8);
-#endif
-    ((unsigned char *)addr)[SPX_OFFSET_KP_ADDR1] = (unsigned char)keypair;
+    u32_to_bytes(&((unsigned char *)addr)[SPX_OFFSET_KP_ADDR], keypair);
 }
 
 /*
@@ -67,10 +62,7 @@ void set_keypair_addr(uint32_t addr[8], uint32_t keypair)
 void copy_keypair_addr(uint32_t out[8], const uint32_t in[8])
 {
     memcpy( out, in, SPX_OFFSET_TREE+8 );
-#if SPX_FULL_HEIGHT/SPX_D > 8
-    ((unsigned char *)out)[SPX_OFFSET_KP_ADDR2] = ((unsigned char *)in)[SPX_OFFSET_KP_ADDR2];
-#endif
-    ((unsigned char *)out)[SPX_OFFSET_KP_ADDR1] = ((unsigned char *)in)[SPX_OFFSET_KP_ADDR1];
+    memcpy( (unsigned char *)out + SPX_OFFSET_KP_ADDR, (unsigned char *)in + SPX_OFFSET_KP_ADDR, 4); 
 }
 
 /*

--- a/ref/haraka_offsets.h
+++ b/ref/haraka_offsets.h
@@ -9,8 +9,7 @@
 #define SPX_OFFSET_LAYER     3   /* The byte used to specify the Merkle tree layer */
 #define SPX_OFFSET_TREE      8   /* The start of the 8 byte field used to specify the tree */
 #define SPX_OFFSET_TYPE      19  /* The byte used to specify the hash type (reason) */
-#define SPX_OFFSET_KP_ADDR2  22  /* The high byte used to specify the key pair (which one-time signature) */
-#define SPX_OFFSET_KP_ADDR1  23  /* The low byte used to specify the key pair */
+#define SPX_OFFSET_KP_ADDR   20  /* The start of the 4 byte field used to specify the key pair address */
 #define SPX_OFFSET_CHAIN_ADDR 27  /* The byte used to specify the chain address (which Winternitz chain) */
 #define SPX_OFFSET_HASH_ADDR 31  /* The byte used to specify the hash address (where in the Winternitz chain) */
 #define SPX_OFFSET_TREE_HGT  27  /* The byte used to specify the height of this node in the FORS or Merkle tree */

--- a/ref/hash_haraka.c
+++ b/ref/hash_haraka.c
@@ -83,8 +83,12 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
     #error For given height and depth, 64 bits cannot represent all subtrees
 #endif
 
-    *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
-    *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);
+    if (SPX_D == 1) {
+	*tree = 0;
+    } else {
+        *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
+        *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);
+    }
     bufp += SPX_TREE_BYTES;
 
     *leaf_idx = (uint32_t)bytes_to_ull(bufp, SPX_LEAF_BYTES);

--- a/ref/hash_sha2.c
+++ b/ref/hash_sha2.c
@@ -182,8 +182,12 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
     #error For given height and depth, 64 bits cannot represent all subtrees
 #endif
 
-    *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
-    *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);
+    if (SPX_D == 1) {
+	*tree = 0;
+    } else {
+        *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
+        *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);
+    }
     bufp += SPX_TREE_BYTES;
 
     *leaf_idx = (uint32_t)bytes_to_ull(bufp, SPX_LEAF_BYTES);

--- a/ref/hash_shake.c
+++ b/ref/hash_shake.c
@@ -84,8 +84,12 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
     #error For given height and depth, 64 bits cannot represent all subtrees
 #endif
 
-    *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
-    *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);
+    if (SPX_D == 1) {
+        *tree = 0;
+    } else {
+        *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
+        *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);
+    }
     bufp += SPX_TREE_BYTES;
 
     *leaf_idx = (uint32_t)bytes_to_ull(bufp, SPX_LEAF_BYTES);

--- a/ref/sha2_offsets.h
+++ b/ref/sha2_offsets.h
@@ -9,8 +9,7 @@
 #define SPX_OFFSET_LAYER     0   /* The byte used to specify the Merkle tree layer */
 #define SPX_OFFSET_TREE      1   /* The start of the 8 byte field used to specify the tree */
 #define SPX_OFFSET_TYPE      9   /* The byte used to specify the hash type (reason) */
-#define SPX_OFFSET_KP_ADDR2  12  /* The high byte used to specify the key pair (which one-time signature) */
-#define SPX_OFFSET_KP_ADDR1  13  /* The low byte used to specify the key pair */
+#define SPX_OFFSET_KP_ADDR   10  /* The start of the 4 byte field used to specify the key pair address */ 
 #define SPX_OFFSET_CHAIN_ADDR 17  /* The byte used to specify the chain address (which Winternitz chain) */
 #define SPX_OFFSET_HASH_ADDR 21  /* The byte used to specify the hash address (where in the Winternitz chain) */
 #define SPX_OFFSET_TREE_HGT  17  /* The byte used to specify the height of this node in the FORS or Merkle tree */

--- a/ref/shake_offsets.h
+++ b/ref/shake_offsets.h
@@ -9,8 +9,7 @@
 #define SPX_OFFSET_LAYER     3   /* The byte used to specify the Merkle tree layer */
 #define SPX_OFFSET_TREE      8   /* The start of the 8 byte field used to specify the tree */
 #define SPX_OFFSET_TYPE      19  /* The byte used to specify the hash type (reason) */
-#define SPX_OFFSET_KP_ADDR2  22  /* The high byte used to specify the key pair (which one-time signature) */
-#define SPX_OFFSET_KP_ADDR1  23  /* The low byte used to specify the key pair */
+#define SPX_OFFSET_KP_ADDR   20  /* The start of the 4 byte field used to specify the key pair address */ 
 #define SPX_OFFSET_CHAIN_ADDR 27  /* The byte used to specify the chain address (which Winternitz chain) */
 #define SPX_OFFSET_HASH_ADDR 31  /* The byte used to specify the hash address (where in the Winternitz chain) */
 #define SPX_OFFSET_TREE_HGT  27  /* The byte used to specify the height of this node in the FORS or Merkle tree */


### PR DESCRIPTION
This includes two changes:
* Copy the full key pair address, to support parameters which have more than > 2^16 leaves in an individual tree. This will now always copy the 4 bytes, which has a barely noticeable performance impact.
* Fixes an undefined behavior if a single tree (d=1) is used, leading to a right shift of 64-bit values by 64.

The other fields are still only copied partially (it seems unlikely they will ever exceed the boundaries, but for correctness we maybe should consider it):
* Chain address would only be > 1 byte if W <= 2.
* Hash address would only be > 1 byte if W > 8 [this may happen, but would lead to very slow parameters].
* Tree height would only be > 1 byte if h/d >=256 or similar if the FORS tree would be >= 256 layers (which will never happen).