### PR TITLE
Add SPDX headers and copyright notices at the beginning of files.

### DIFF
--- a/haraka-aesni/Makefile
+++ b/haraka-aesni/Makefile
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+# Copyright: TBD
+
 PARAMS = sphincs-haraka-128f
 THASH = robust
 

--- a/ref/Makefile
+++ b/ref/Makefile
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+# Copyright: TBD
+
 PARAMS = sphincs-haraka-128f
 THASH = robust
 

--- a/ref/PQCgenKAT_sign.c
+++ b/ref/PQCgenKAT_sign.c
@@ -1,10 +1,14 @@
+/*
+ * SPDX-License-Identifier: NIST-Software
+ * Copyright: National Institute of Standards and Technology; The software developed by NIST employees is not subject to copyright protection within the United States.
+ *
+NIST-developed software is provided by NIST as a public service. You may use, copy, and distribute copies of the software in any medium, provided that you keep intact this entire notice. You may improve, modify, and create derivative works of the software or any portion of the software, and you may copy and distribute such modifications or works. Modified works should carry a notice stating that you changed the software and should note the date and nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the source of the software.
 
-//
-//  PQCgenKAT_sign.c
-//
-//  Created by Bassham, Lawrence E (Fed) on 8/29/17.
-//  Copyright © 2017 Bassham, Lawrence E (Fed). All rights reserved.
-//
+NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+
+You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
+*/
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/ref/address.c
+++ b/ref/address.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/ref/address.h
+++ b/ref/address.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_ADDRESS_H
 #define SPX_ADDRESS_H
 

--- a/ref/api.h
+++ b/ref/api.h
@@ -1,3 +1,14 @@
+/*
+ * SPDX-License-Identifier: NIST-Software
+ * Copyright: National Institute of Standards and Technology; The software developed by NIST employees is not subject to copyright protection within the United States.
+ *
+NIST-developed software is provided by NIST as a public service. You may use, copy, and distribute copies of the software in any medium, provided that you keep intact this entire notice. You may improve, modify, and create derivative works of the software or any portion of the software, and you may copy and distribute such modifications or works. Modified works should carry a notice stating that you changed the software and should note the date and nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the source of the software.
+
+NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+
+You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
+*/
+
 #ifndef SPX_API_H
 #define SPX_API_H
 

--- a/ref/context.h
+++ b/ref/context.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_CONTEXT_H
 #define SPX_CONTEXT_H
 

--- a/ref/fips202.c
+++ b/ref/fips202.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 /* Based on the public domain implementation in
  * crypto_hash/keccakc512/simple/ from http://bench.cr.yp.to/supercop.html
  * by Ronny Van Keer

--- a/ref/fips202.h
+++ b/ref/fips202.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_FIPS202_H
 #define SPX_FIPS202_H
 

--- a/ref/fors.c
+++ b/ref/fors.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>

--- a/ref/fors.h
+++ b/ref/fors.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_FORS_H
 #define SPX_FORS_H
 

--- a/ref/haraka.c
+++ b/ref/haraka.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ *
  * Constant time implementation of the Haraka hash function.
  *
  * The bit-sliced implementation of the AES round functions are

--- a/ref/haraka.h
+++ b/ref/haraka.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_HARAKA_H
 #define SPX_HARAKA_H
 

--- a/ref/haraka_offsets.h
+++ b/ref/haraka_offsets.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #if !defined( HARAKA_OFFSETS_H_ )
 #define HARAKA_OFFSETS_H_
 

--- a/ref/hash.h
+++ b/ref/hash.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_HASH_H
 #define SPX_HASH_H
 

--- a/ref/hash_haraka.c
+++ b/ref/hash_haraka.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/ref/hash_sha2.c
+++ b/ref/hash_sha2.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/ref/hash_shake.c
+++ b/ref/hash_shake.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/ref/merkle.c
+++ b/ref/merkle.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/ref/merkle.h
+++ b/ref/merkle.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #if !defined( MERKLE_H_ )
 #define MERKLE_H_
 

--- a/ref/params.h
+++ b/ref/params.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #define str(s) #s
 #define xstr(s) str(s)
 

--- a/ref/params/params-sphincs-haraka-128f.h
+++ b/ref/params/params-sphincs-haraka-128f.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 

--- a/ref/params/params-sphincs-haraka-128s.h
+++ b/ref/params/params-sphincs-haraka-128s.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 

--- a/ref/params/params-sphincs-haraka-192f.h
+++ b/ref/params/params-sphincs-haraka-192f.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 

--- a/ref/params/params-sphincs-haraka-192s.h
+++ b/ref/params/params-sphincs-haraka-192s.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 

--- a/ref/params/params-sphincs-haraka-256f.h
+++ b/ref/params/params-sphincs-haraka-256f.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 

--- a/ref/params/params-sphincs-haraka-256s.h
+++ b/ref/params/params-sphincs-haraka-256s.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 

--- a/ref/params/params-sphincs-sha2-128f.h
+++ b/ref/params/params-sphincs-sha2-128f.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 

--- a/ref/params/params-sphincs-sha2-128s.h
+++ b/ref/params/params-sphincs-sha2-128s.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 

--- a/ref/params/params-sphincs-sha2-192f.h
+++ b/ref/params/params-sphincs-sha2-192f.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 

--- a/ref/params/params-sphincs-sha2-192s.h
+++ b/ref/params/params-sphincs-sha2-192s.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 

--- a/ref/params/params-sphincs-sha2-256f.h
+++ b/ref/params/params-sphincs-sha2-256f.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 

--- a/ref/params/params-sphincs-sha2-256s.h
+++ b/ref/params/params-sphincs-sha2-256s.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 

--- a/ref/params/params-sphincs-shake-128f.h
+++ b/ref/params/params-sphincs-shake-128f.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 

--- a/ref/params/params-sphincs-shake-128s.h
+++ b/ref/params/params-sphincs-shake-128s.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 

--- a/ref/params/params-sphincs-shake-192f.h
+++ b/ref/params/params-sphincs-shake-192f.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 

--- a/ref/params/params-sphincs-shake-192s.h
+++ b/ref/params/params-sphincs-shake-192s.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 

--- a/ref/params/params-sphincs-shake-256f.h
+++ b/ref/params/params-sphincs-shake-256f.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 

--- a/ref/params/params-sphincs-shake-256s.h
+++ b/ref/params/params-sphincs-shake-256s.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_PARAMS_H
 #define SPX_PARAMS_H
 

--- a/ref/randombytes.c
+++ b/ref/randombytes.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 /*
 This code was taken from the SPHINCS reference implementation and is public domain.
 */

--- a/ref/randombytes.h
+++ b/ref/randombytes.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_RANDOMBYTES_H
 #define SPX_RANDOMBYTES_H
 

--- a/ref/rng.c
+++ b/ref/rng.c
@@ -1,9 +1,13 @@
-//
-//  rng.c
-//
-//  Created by Bassham, Lawrence E (Fed) on 8/29/17.
-//  Copyright © 2017 Bassham, Lawrence E (Fed). All rights reserved.
-//
+/*
+ * SPDX-License-Identifier: NIST-Software
+ * Copyright: National Institute of Standards and Technology; The software developed by NIST employees is not subject to copyright protection within the United States.
+ *
+NIST-developed software is provided by NIST as a public service. You may use, copy, and distribute copies of the software in any medium, provided that you keep intact this entire notice. You may improve, modify, and create derivative works of the software or any portion of the software, and you may copy and distribute such modifications or works. Modified works should carry a notice stating that you changed the software and should note the date and nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the source of the software.
+
+NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+
+You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
+*/
 
 #include <string.h>
 #include "rng.h"

--- a/ref/rng.h
+++ b/ref/rng.h
@@ -1,9 +1,13 @@
-//
-//  rng.h
-//
-//  Created by Bassham, Lawrence E (Fed) on 8/29/17.
-//  Copyright © 2017 Bassham, Lawrence E (Fed). All rights reserved.
-//
+/*
+ * SPDX-License-Identifier: NIST-Software
+ * Copyright: National Institute of Standards and Technology; The software developed by NIST employees is not subject to copyright protection within the United States.
+ *
+NIST-developed software is provided by NIST as a public service. You may use, copy, and distribute copies of the software in any medium, provided that you keep intact this entire notice. You may improve, modify, and create derivative works of the software or any portion of the software, and you may copy and distribute such modifications or works. Modified works should carry a notice stating that you changed the software and should note the date and nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the source of the software.
+
+NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+
+You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
+*/
 
 #ifndef rng_h
 #define rng_h

--- a/ref/sha2.c
+++ b/ref/sha2.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 /* Based on the public domain implementation in
  * crypto_hash/sha512/ref/ from http://bench.cr.yp.to/supercop.html
  * by D. J. Bernstein */

--- a/ref/sha2.h
+++ b/ref/sha2.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_SHA2_H
 #define SPX_SHA2_H
 

--- a/ref/sha2_offsets.h
+++ b/ref/sha2_offsets.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SHA2_OFFSETS_H_
 #define SHA2_OFFSETS_H_
 

--- a/ref/shake_offsets.h
+++ b/ref/shake_offsets.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #if !defined( SHAKE_OFFSETS_H_ )
 #define SHAKE_OFFSETS_H_
 

--- a/ref/sign.c
+++ b/ref/sign.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stddef.h>
 #include <string.h>
 #include <stdint.h>

--- a/ref/test/benchmark.c
+++ b/ref/test/benchmark.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #define _POSIX_C_SOURCE 199309L
 
 #include <stdio.h>

--- a/ref/test/cycles.c
+++ b/ref/test/cycles.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #include "cycles.h"
 
 #if defined(__aarch64__) && defined(__APPLE__)

--- a/ref/test/cycles.h
+++ b/ref/test/cycles.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_CYCLES_H
 #define SPX_CYCLES_H
 

--- a/ref/test/fors.c
+++ b/ref/test/fors.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #include <stdio.h>
 #include <string.h>
 

--- a/ref/test/haraka.c
+++ b/ref/test/haraka.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>

--- a/ref/test/spx.c
+++ b/ref/test/spx.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/ref/thash.h
+++ b/ref/thash.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_THASH_H
 #define SPX_THASH_H
 

--- a/ref/thash_haraka_robust.c
+++ b/ref/thash_haraka_robust.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/ref/thash_haraka_simple.c
+++ b/ref/thash_haraka_simple.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/ref/thash_sha2_robust.c
+++ b/ref/thash_sha2_robust.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/ref/thash_sha2_simple.c
+++ b/ref/thash_sha2_simple.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/ref/thash_shake_robust.c
+++ b/ref/thash_shake_robust.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/ref/thash_shake_simple.c
+++ b/ref/thash_shake_simple.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/ref/utils.c
+++ b/ref/utils.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <string.h>
 
 #include "utils.h"

--- a/ref/utils.h
+++ b/ref/utils.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_UTILS_H
 #define SPX_UTILS_H
 

--- a/ref/utilsx1.c
+++ b/ref/utilsx1.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <string.h>
 
 #include "utils.h"

--- a/ref/utilsx1.h
+++ b/ref/utilsx1.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_UTILSX4_H
 #define SPX_UTILSX4_H
 

--- a/ref/wots.c
+++ b/ref/wots.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/ref/wots.h
+++ b/ref/wots.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_WOTS_H
 #define SPX_WOTS_H
 

--- a/ref/wotsx1.c
+++ b/ref/wotsx1.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/ref/wotsx1.h
+++ b/ref/wotsx1.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #if !defined( WOTSX1_H_ )
 #define WOTSX1_H_ 
 

--- a/sha2-avx2/Makefile
+++ b/sha2-avx2/Makefile
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+# Copyright: TBD
+
 PARAMS = sphincs-sha2-128f
 THASH = robust
 

--- a/sha2-avx2/context.h
+++ b/sha2-avx2/context.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_CONTEXT_H
 #define SPX_CONTEXT_H
 

--- a/sha2-avx2/fors.c
+++ b/sha2-avx2/fors.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>

--- a/sha2-avx2/hash_sha2x8.c
+++ b/sha2-avx2/hash_sha2x8.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/sha2-avx2/hashx8.h
+++ b/sha2-avx2/hashx8.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_HASHX8_H
 #define SPX_HASHX8_H
 

--- a/sha2-avx2/merkle.c
+++ b/sha2-avx2/merkle.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/sha2-avx2/sha256avx.c
+++ b/sha2-avx2/sha256avx.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>

--- a/sha2-avx2/sha256avx.h
+++ b/sha2-avx2/sha256avx.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SHA256AVX_H
 #define SHA256AVX_H
 #include "immintrin.h"

--- a/sha2-avx2/sha256x8.c
+++ b/sha2-avx2/sha256x8.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <string.h>
 
 #include "sha256x8.h"

--- a/sha2-avx2/sha256x8.h
+++ b/sha2-avx2/sha256x8.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_SHA256X8_H
 #define SPX_SHA256X8_H
 

--- a/sha2-avx2/sha512x4.c
+++ b/sha2-avx2/sha512x4.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>

--- a/sha2-avx2/sha512x4.h
+++ b/sha2-avx2/sha512x4.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SHA512AVX_H
 #define SHA512AVX_H
 #include <stdint.h>

--- a/sha2-avx2/test/benchmark.c
+++ b/sha2-avx2/test/benchmark.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #define _POSIX_C_SOURCE 199309L
 
 #include <stdio.h>

--- a/sha2-avx2/test/thashx8.c
+++ b/sha2-avx2/test/thashx8.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #include <stdio.h>
 #include <string.h>
 

--- a/sha2-avx2/thash_sha2_robustx8.c
+++ b/sha2-avx2/thash_sha2_robustx8.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/sha2-avx2/thash_sha2_simplex8.c
+++ b/sha2-avx2/thash_sha2_simplex8.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/sha2-avx2/thashx8.h
+++ b/sha2-avx2/thashx8.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_THASHX8_H
 #define SPX_THASHX8_H
 

--- a/sha2-avx2/utilsx8.c
+++ b/sha2-avx2/utilsx8.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <string.h>
 
 #include "utils.h"

--- a/sha2-avx2/utilsx8.h
+++ b/sha2-avx2/utilsx8.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_UTILSX8_H
 #define SPX_UTILSX8_H
 

--- a/sha2-avx2/wots.c
+++ b/sha2-avx2/wots.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/sha2-avx2/wotsx8.h
+++ b/sha2-avx2/wotsx8.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #if !defined( WOTSX8_H_ )
 #define WOTSX8_H_ 
 

--- a/shake-a64/Makefile
+++ b/shake-a64/Makefile
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+# Copyright: TBD
+
 PARAMS = sphincs-shake-128f
 THASH = robust
 

--- a/shake-a64/context.h
+++ b/shake-a64/context.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_CONTEXT_H
 #define SPX_CONTEXT_H
 

--- a/shake-a64/f1600x2.h
+++ b/shake-a64/f1600x2.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_F1600X2_H
 #define SPX_F1600X2_H
 

--- a/shake-a64/f1600x2.s
+++ b/shake-a64/f1600x2.s
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 # From https://github.com/bwesterb/armed-keccak
 
 .macro round

--- a/shake-a64/f1600x2_const.c
+++ b/shake-a64/f1600x2_const.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include "f1600x2.h"
 
 uint64_t f1600_RC[24] = {

--- a/shake-a64/fips202x2.c
+++ b/shake-a64/fips202x2.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <assert.h>
 

--- a/shake-a64/fips202x2.h
+++ b/shake-a64/fips202x2.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_FIPS202X2_H
 #define SPX_FIPS202X2_H
 

--- a/shake-a64/fors.c
+++ b/shake-a64/fors.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>

--- a/shake-a64/hash_shakex2.c
+++ b/shake-a64/hash_shakex2.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/shake-a64/hashx2.h
+++ b/shake-a64/hashx2.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_HASHX2_H
 #define SPX_HASHX2_H
 

--- a/shake-a64/merkle.c
+++ b/shake-a64/merkle.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/shake-a64/test/benchmark.c
+++ b/shake-a64/test/benchmark.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #define _POSIX_C_SOURCE 199309L
 
 #include <stdio.h>

--- a/shake-a64/test/thashx2.c
+++ b/shake-a64/test/thashx2.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #include <stdio.h>
 #include <string.h>
 

--- a/shake-a64/thash.h
+++ b/shake-a64/thash.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_THASHX2_AS_ONE
 #define SPX_THASHX2_AS_ONE
 

--- a/shake-a64/thash_shake_robustx2.c
+++ b/shake-a64/thash_shake_robustx2.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/shake-a64/thash_shake_simplex2.c
+++ b/shake-a64/thash_shake_simplex2.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/shake-a64/thashx2.h
+++ b/shake-a64/thashx2.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_THASHX2_H
 #define SPX_THASHX2_H
 

--- a/shake-a64/utilsx2.c
+++ b/shake-a64/utilsx2.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <string.h>
 
 #include "utils.h"

--- a/shake-a64/utilsx2.h
+++ b/shake-a64/utilsx2.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_UTILSX2_H
 #define SPX_UTILSX2_H
 

--- a/shake-a64/wots.c
+++ b/shake-a64/wots.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/shake-a64/wotsx2.h
+++ b/shake-a64/wotsx2.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #if !defined( WOTSX2_H_ )
 #define WOTSX2_H_ 
 

--- a/shake-avx2/Makefile
+++ b/shake-avx2/Makefile
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+# Copyright: TBD
+
 PARAMS = sphincs-shake-128f
 THASH = robust
 

--- a/shake-avx2/context.h
+++ b/shake-avx2/context.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_CONTEXT_H
 #define SPX_CONTEXT_H
 

--- a/shake-avx2/fips202x4.c
+++ b/shake-avx2/fips202x4.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <immintrin.h>
 #include <stdint.h>
 #include <assert.h>

--- a/shake-avx2/fips202x4.h
+++ b/shake-avx2/fips202x4.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_FIPS202X4_H
 #define SPX_FIPS202X4_H
 

--- a/shake-avx2/fors.c
+++ b/shake-avx2/fors.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>

--- a/shake-avx2/hash_shakex4.c
+++ b/shake-avx2/hash_shakex4.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/shake-avx2/hashx4.h
+++ b/shake-avx2/hashx4.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_HASHX4_H
 #define SPX_HASHX4_H
 

--- a/shake-avx2/keccak4x/KeccakP-1600-times4-SIMD256.c
+++ b/shake-avx2/keccak4x/KeccakP-1600-times4-SIMD256.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 /*
 Implementation by the Keccak, Keyak and Ketje Teams, namely, Guido Bertoni,
 Joan Daemen, Michaël Peeters, Gilles Van Assche and Ronny Van Keer, hereby

--- a/shake-avx2/keccak4x/KeccakP-1600-times4-SnP.h
+++ b/shake-avx2/keccak4x/KeccakP-1600-times4-SnP.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 /*
 Implementation by the Keccak, Keyak and Ketje Teams, namely, Guido Bertoni,
 Joan Daemen, Michaël Peeters, Gilles Van Assche and Ronny Van Keer, hereby

--- a/shake-avx2/keccak4x/KeccakP-1600-unrolling.macros
+++ b/shake-avx2/keccak4x/KeccakP-1600-unrolling.macros
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 /*
 Implementation by the Keccak, Keyak and Ketje Teams, namely, Guido Bertoni,
 Joan Daemen, Michaël Peeters, Gilles Van Assche and Ronny Van Keer, hereby

--- a/shake-avx2/keccak4x/SIMD256-config.h
+++ b/shake-avx2/keccak4x/SIMD256-config.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #define KeccakP1600times4_implementation_config "AVX2, all rounds unrolled"
 #define KeccakP1600times4_fullUnrolling
 #define KeccakP1600times4_useAVX2

--- a/shake-avx2/keccak4x/align.h
+++ b/shake-avx2/keccak4x/align.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 /*
 Implementation by the Keccak, Keyak and Ketje Teams, namely, Guido Bertoni,
 Joan Daemen, Michaël Peeters, Gilles Van Assche and Ronny Van Keer, hereby

--- a/shake-avx2/keccak4x/brg_endian.h
+++ b/shake-avx2/keccak4x/brg_endian.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Brian-Gladman-3-Clause
  ---------------------------------------------------------------------------
  Copyright (c) 1998-2008, Brian Gladman, Worcester, UK. All rights reserved.
 

--- a/shake-avx2/merkle.c
+++ b/shake-avx2/merkle.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/shake-avx2/test/benchmark.c
+++ b/shake-avx2/test/benchmark.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #define _POSIX_C_SOURCE 199309L
 
 #include <stdio.h>

--- a/shake-avx2/test/thashx4.c
+++ b/shake-avx2/test/thashx4.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0 OR 0BSD OR MIT-0 OR LicenseRef-SPHINCS-PLUS-Public-Domain
+ * Copyright: TBD
+ * */
+
 #include <stdio.h>
 #include <string.h>
 

--- a/shake-avx2/thash_shake_robustx4.c
+++ b/shake-avx2/thash_shake_robustx4.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/shake-avx2/thash_shake_simplex4.c
+++ b/shake-avx2/thash_shake_simplex4.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/shake-avx2/thashx4.h
+++ b/shake-avx2/thashx4.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_THASHX4_H
 #define SPX_THASHX4_H
 

--- a/shake-avx2/utilsx4.c
+++ b/shake-avx2/utilsx4.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <string.h>
 
 #include "utils.h"

--- a/shake-avx2/utilsx4.h
+++ b/shake-avx2/utilsx4.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #ifndef SPX_UTILSX4_H
 #define SPX_UTILSX4_H
 

--- a/shake-avx2/wots.c
+++ b/shake-avx2/wots.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #include <stdint.h>
 #include <string.h>
 

--- a/shake-avx2/wotsx4.h
+++ b/shake-avx2/wotsx4.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: (LicenseRef-SPHINCS-PLUS-Public-Domain OR CC0-1.0 OR 0BSD OR MIT-0) AND MIT
+ * Copyright: TBD
+ * */
+
 #if !defined( WOTSX4_H_ )
 #define WOTSX4_H_
 


### PR DESCRIPTION
In downstream projects, files may be copied and moved around. This makes it difficult to track the copyrights and licenses without having them stored in each file.

I started with .reuse/dep5 but I've also noticed some things:
- for Files: *, there is no Copyright: entry which is required by the Debian machine-readable copyright format (and debian packaging is my ultimate goal)
- for Files: *, License: is not the same as in the LICENSE file (no AND MIT clause)

I've eyed making these changes in a way that would permit creating .reuse/dep5 again in an automated fashion. This isn't possible due to the differences I outline here and due to the tools available but that was a goal (and explains why I changed */Makefile too).

While license was fine, I had an issue with copyrights which are not indicated in the project but are required by Debian. I've used "Copyright: TBD" in headers but I'd like to fix that obviously.

Moreover, I've chosen to use the most recent copyright/license/* header for ref/{api.h, PQCgenKAT_sign.c,rng.c,rng.h} based on the files at https://csrc.nist.gov/Projects/pqc-dig-sig/standardization/example-files because "All rights reserved." is not a valid license. This had the effect of changing Copyright: too but I think it is more meaningful now. The actual code for these files has changed too but upon review, the changes are all very minor.